### PR TITLE
Update ES6 module transpiler and proper sourcemap concatenation

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -1,14 +1,14 @@
-var concat     = require('broccoli-concat');
 var pickFiles  = require('broccoli-static-compiler');
 var mergeTrees = require('broccoli-merge-trees');
-var compileES6 = require('broccoli-es6-concatenator');
+var compileES6 = require('broccoli-es6modules');
+var concat   = require('broccoli-sourcemap-concat');
 
 // --- Compile ES6 modules ---
 
 var loader = pickFiles('bower_components', {
   srcDir: 'loader',
   files: ['loader.js'],
-  destDir: '/'
+  destDir: '/assets'
 });
 
 var klassy = pickFiles('bower_components', {
@@ -29,11 +29,11 @@ var tests = pickFiles('tests', {
   destDir: '/tests'
 });
 
-var main = mergeTrees([loader, klassy, lib, tests]);
-main = compileES6(main, {
-  loaderFile: '/loader.js',
+var main = mergeTrees([klassy, lib, tests]);
+main = new compileES6(main);
+
+main = concat(main, {
   inputFiles: ['**/*.js'],
-  ignoredModules: ['ember'],
   outputFile: '/assets/ember-test-helpers-tests.amd.js'
 });
 
@@ -65,4 +65,4 @@ var testSupport = concat('bower_components', {
   outputFile: '/assets/test-support.js'
 });
 
-module.exports = mergeTrees([main, vendor, testIndex, qunit, testSupport]);
+module.exports = mergeTrees([main, vendor, testIndex, qunit, loader, testSupport]);

--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
   "readmeFilename": "README.md",
   "devDependencies": {
     "broccoli": "^0.13.0",
-    "broccoli-concat": "^0.0.11",
-    "broccoli-es6-concatenator": "^0.1.7",
+    "broccoli-es6modules": "^0.4.0",
     "broccoli-merge-trees": "^0.1.4",
+    "broccoli-sourcemap-concat": "^0.4.3",
     "broccoli-static-compiler": "^0.1.4",
     "testem": "^0.6.19"
   }

--- a/testem.json
+++ b/testem.json
@@ -2,6 +2,7 @@
   "framework": "qunit",
   "cwd": "build/",
   "serve_files": [
+    "assets/loader.js",
     "assets/vendor.js",
     "assets/ember-test-helpers-tests.amd.js",
     "assets/test-support.js"

--- a/tests/index.html
+++ b/tests/index.html
@@ -8,6 +8,7 @@
 <body>
   <div id="qunit"></div>
   <div id="qunit-fixture"></div>
+  <script src="/assets/loader.js"></script>
   <script src="/assets/vendor.js"></script>
   <script src="/assets/qunit.js"></script>
   <script src="/assets/ember-test-helpers-tests.amd.js"></script>


### PR DESCRIPTION
We're trying to update loader js in https://github.com/ember-cli/ember-cli/pull/3054 and we noticed that ember-test-helpers were producing an incorrect AMD output.  This PR replaces the old ES6 transpiler for the one that is used by Ember CLI and produces the correct output.  I also added the sourcemap concatenator which knows how to properly concat sourcemaps.