### PR TITLE
Ensure that `setup` callback is invoked with the correct context.

### DIFF
--- a/lib/ember-test-helpers/test-module.js
+++ b/lib/ember-test-helpers/test-module.js
@@ -36,6 +36,7 @@ export default Klass.extend({
 
   initSetupSteps: function() {
     this.setupSteps = [];
+    this.contextualizedSetupSteps = [];
 
     if (this.callbacks.beforeSetup) {
       this.setupSteps.push( this.callbacks.beforeSetup );
@@ -47,42 +48,50 @@ export default Klass.extend({
     this.setupSteps.push(this.setupTestElements);
 
     if (this.callbacks.setup) {
-      this.setupSteps.push( this.callbacks.setup );
+      this.contextualizedSetupSteps.push( this.callbacks.setup );
       delete this.callbacks.setup;
     }
   },
 
   initTeardownSteps: function() {
     this.teardownSteps = [];
+    this.contextualizedTeardownSteps = [];
 
-    if (this.callbacks.beforeTeardown) {
-      this.teardownSteps.push( this.callbacks.beforeTeardown );
-      delete this.callbacks.beforeTeardown;
+    if (this.callbacks.teardown) {
+      this.contextualizedTeardownSteps.push( this.callbacks.teardown );
+      delete this.callbacks.teardown;
     }
 
     this.teardownSteps.push(this.teardownContainer);
     this.teardownSteps.push(this.teardownContext);
     this.teardownSteps.push(this.teardownTestElements);
 
-    if (this.callbacks.teardown) {
-      this.teardownSteps.push( this.callbacks.teardown );
-      delete this.callbacks.teardown;
+    if (this.callbacks.afterTeardown) {
+      this.teardownSteps.push( this.callbacks.afterTeardown );
+      delete this.callbacks.beforeTeardown;
     }
   },
 
   setup: function() {
     this.invokeSteps(this.setupSteps);
     this.contextualizeCallbacks();
+    this.invokeSteps(this.contextualizedSetupSteps, this.context);
   },
 
   teardown: function() {
+    this.invokeSteps(this.contextualizedTeardownSteps, this.context);
     this.invokeSteps(this.teardownSteps);
     this.cache = null;
   },
 
-  invokeSteps: function(steps) {
+  invokeSteps: function(steps, _context) {
+    var context = _context;
+    if (!context) {
+      context = this;
+    }
+
     for (var i = 0, l = steps.length; i < l; i++) {
-      steps[i].call(this);
+      steps[i].call(context);
     }
   },
 

--- a/tests/test-module-for-component-test.js
+++ b/tests/test-module-for-component-test.js
@@ -185,3 +185,24 @@ test("$", function(){
   equal($.trim(this.$('.color-name').text()), 'green');
   equal($.trim(this.$().text()), 'Pretty Color: green');
 });
+
+moduleForComponent('pretty-color', 'component:pretty-color -- this.render in setup', {
+  beforeSetup: function() {
+    setupRegistry();
+  },
+
+  setup: function() {
+    this.subject({
+      name: 'red'
+    });
+
+    this.render();
+  }
+});
+
+test("className", function(){
+  // calling `this.$` or `this.subject.$` would
+  // force it to `render` initially, so we access the `ember-testing`
+  // div contents directly
+  equal($.trim($('#ember-testing').text()), 'Pretty Color: red');
+});


### PR DESCRIPTION
Previously, the `setup` callback was invoked via `invokeSteps` (and
therefore was bound to the `TestModule` instance itself).  Now it is
invoked with the same context as the tests themselves.

* Ensure `setup` callback is invoked with the test context.
* Ensure `teardown` callback is invoked with the test context.
* Removed `beforeTeardown`.
* Added `afterTeardown` which is invoked with the test-module context.
* Simplify callback ordering tests.

/cc @dgeb