### PR TITLE
Ensure callbacks are called in the test module's context.

### DIFF
--- a/lib/ember-test-helpers/test-module-for-component.js
+++ b/lib/ember-test-helpers/test-module-for-component.js
@@ -49,7 +49,7 @@ export default TestModule.extend({
 
     this.callbacks.append = function() {
       Ember.deprecate('this.append() is deprecated. Please use this.render() instead.');
-      return this.render();
+      return this.callbacks.render();
     };
 
     context.$ = function() {

--- a/lib/ember-test-helpers/test-module.js
+++ b/lib/ember-test-helpers/test-module.js
@@ -164,7 +164,8 @@ export default Klass.extend({
         context[key] = function(options) {
           if (_this.cache[key]) { return _this.cache[key]; }
 
-          var result = callbacks[key](options, factory());
+          var result = callbacks[key].call(_this, options, factory());
+
           _this.cache[key] = result;
 
           return result;

--- a/tests/test-module-test.js
+++ b/tests/test-module-test.js
@@ -83,3 +83,17 @@ test("can lookup factory registered in setup", function() {
 
   equal(service.get('purpose'), 'blabering');
 });
+
+moduleFor('component:x-foo', 'component:x-foo -- callback context', {
+  beforeSetup: function() {
+    setupRegistry();
+  },
+
+  getSubjectName: function() {
+    return this.subjectName;
+  }
+});
+
+test("callbacks are called in the context of the module", function() {
+  equal(this.getSubjectName(), 'component:x-foo');
+});


### PR DESCRIPTION
Provides access to any of a module's properties (e.g. `container`, `callbacks`, etc.) from within a callback.

Attn: @rwjblue 