### PR TITLE
Expose registry methods from isolatedContainer without deprecations.

### DIFF
--- a/lib/ember-test-helpers/isolated-container.js
+++ b/lib/ember-test-helpers/isolated-container.js
@@ -1,9 +1,45 @@
 import { getResolver } from './test-resolver';
 import Ember from 'ember';
 
+function exposeRegistryMethodsWithoutDeprecations(container) {
+  var methods = [
+    'register',
+    'unregister',
+    'resolve',
+    'normalize',
+    'typeInjection',
+    'injection',
+    'factoryInjection',
+    'factoryTypeInjection',
+    'has',
+    'options',
+    'optionsForType'
+  ];
+
+  function exposeRegistryMethod(container, method) {
+    container[method] = function() {
+      return container._registry[method].apply(container._registry, arguments);
+    };
+  }
+
+  for (var i = 0, l = methods.length; i < l; i++) {
+    exposeRegistryMethod(container, methods[i]);
+  }
+}
+
 export default function isolatedContainer(fullNames) {
   var resolver = getResolver();
-  var container = new Ember.Container();
+  var container;
+
+  if (Ember.Registry) {
+    var registry = new Ember.Registry();
+    container = registry.container();
+    exposeRegistryMethodsWithoutDeprecations(container);
+
+  } else {
+    container = new Ember.Container();
+  }
+
   var normalize = function(fullName) {
     return resolver.normalize(fullName);
   };


### PR DESCRIPTION
Prevent noisy deprecation warnings in tests until we introduce usage
of the ApplicationInstance (complete with its own container and 
registry) into ember-test-helpers.

Tested with ember 1.11 beta as well as 1.10.

Attn: @rwjblue 