### PR TITLE
Component not in dom in willDestroyElement

### DIFF
--- a/lib/ember-test-helpers/test-module-for-component.js
+++ b/lib/ember-test-helpers/test-module-for-component.js
@@ -38,7 +38,7 @@ export default TestModule.extend({
         return subject;
       });
 
-      _this.teardownSteps.push(function() {
+      _this.teardownSteps.unshift(function() {
         Ember.run(function() {
           Ember.tryInvoke(containerView, 'destroy');
         });

--- a/tests/test-module-for-component-test.js
+++ b/tests/test-module-for-component-test.js
@@ -30,10 +30,20 @@ var ColorController = Ember.ObjectController.extend({
   }.property('model')
 });
 
+var BoringColor = Ember.Component.extend({
+  willDestroyElement: function(){
+    var stateIndicatesInDOM = (this._state === 'inDOM');
+    var actuallyInDOM = Ember.$.contains(document, this.$()[0]);
+
+    ok((actuallyInDOM === true) && (actuallyInDOM === stateIndicatesInDOM), 'component should still be in the DOM')
+  }
+});
+
 function setupRegistry() {
   setResolverRegistry({
     'component:x-foo': Ember.Component.extend(),
     'component:pretty-color': PrettyColor,
+    'component:boring-color': BoringColor,
     'template:components/pretty-color': Ember.Handlebars.compile('Pretty Color: <span class="color-name">{{name}}</span>'),
     'controller:color': ColorController
   });
@@ -205,4 +215,19 @@ test("className", function(){
   // force it to `render` initially, so we access the `ember-testing`
   // div contents directly
   equal($.trim($('#ember-testing').text()), 'Pretty Color: red');
+});
+
+moduleForComponent('boring-color', 'component:boring-color -- still in DOM in willDestroyElement', {
+  beforeSetup: function() {
+    setupRegistry();
+  },
+
+  setup: function() {
+    this.render();
+  }
+});
+
+test("className", function(){
+  expect(1)
+  // the assertion is in the willDestroyElement() hook of the component
 });


### PR DESCRIPTION
We found this issue when upgrading ember-cli to 0.1.15

It seems that a change introduced in the new version of ember-test-helpers causes our component tests to fail because the element is no longer in the DOM when the `willDestroyElement` hook is called.

We use a jquery ui datepicker component that cleans itself up in the `willDestroyElement` hook, but now when we run the tests the jquery ui datepicker code errors because it can't destroy the datepicker on the component's element. 

In `test-module-for-component.js` a teardown is added to `teardownSteps` that destroys the containing view:
https://github.com/switchfly/ember-test-helpers/blob/master/lib/ember-test-helpers/test-module-for-component.js#L41

but it looks like that teardown is added after `teardownTestElements` in `test-module.js` is added:
https://github.com/switchfly/ember-test-helpers/blob/master/lib/ember-test-helpers/test-module.js#L65-L67

and `teardownTestElements` empties the test div using jquery without letting Ember know:
https://github.com/switchfly/ember-test-helpers/blob/master/lib/ember-test-helpers/test-module.js#L141-L144

It seems like a fix would be to prepend the module-for-component's teardown -- not sure if this is the right way to do it, but it allows the test in this PR to pass and it allows our project's failing tests to pass:

````javascript
_this.teardownSteps.unshift(function() {
  // ...
}
````

Is there a better fix for this issue?