### PR TITLE
make sure bower_components folder is where broccoli expects

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,3 @@
+{
+    "directory": "bower_components"
+}


### PR DESCRIPTION
Bower components were installing into `app/bower_components` due to a mysterious `.bowerrc` file higher up in my file system. `npm start' would fail because bower-components were not being found. This makes sure bower components will be installed where broccoli expects them.