### PR TITLE
destroy the subject in teardown

### DIFF
--- a/lib/ember-test-helpers/test-module.js
+++ b/lib/ember-test-helpers/test-module.js
@@ -62,6 +62,7 @@ export default Klass.extend({
       delete this.callbacks.teardown;
     }
 
+    this.teardownSteps.push(this.teardownSubject);
     this.teardownSteps.push(this.teardownContainer);
     this.teardownSteps.push(this.teardownContext);
     this.teardownSteps.push(this.teardownTestElements);
@@ -119,6 +120,16 @@ export default Klass.extend({
   setupTestElements: function() {
     if (Ember.$('#ember-testing').length === 0) {
       Ember.$('<div id="ember-testing"/>').appendTo(document.body);
+    }
+  },
+
+  teardownSubject: function() {
+    var subject = this.cache.subject;
+
+    if (subject) {
+      Ember.run(function() {
+        Ember.tryInvoke(subject, 'destroy');
+      });
     }
   },
 

--- a/tests/test-module-test.js
+++ b/tests/test-module-test.js
@@ -97,3 +97,29 @@ moduleFor('component:x-foo', 'component:x-foo -- callback context', {
 test("callbacks are called in the context of the module", function() {
   equal(this.getSubjectName(), 'component:x-foo');
 });
+
+moduleFor('component:x-foo', 'component:x-foo -- created subjects are cleaned up', {
+  beforeSetup: function() {
+    setupRegistry();
+  },
+
+  afterTeardown: function() {
+    var subject = this.cache.subject;
+
+    ok(subject.isDestroyed);
+  }
+});
+
+test("subject's created in a test are destroyed", function() {
+  this.subject();
+});
+
+moduleFor('component:x-foo', 'component:x-foo -- uncreated subjects do not error', {
+  beforeSetup: function() {
+    setupRegistry();
+  }
+});
+
+test("subject's created in a test are destroyed", function() {
+  expect(0);
+});


### PR DESCRIPTION
I'm not sure what there is to test here so I didn't add any tests yet. 

Currently the container is destroyed which takes care of destroying any dependencies brought in by `needs` but the subject is never properly town down. This makes sure that happens.