### PR TITLE
Adding standalone integration test support

### DIFF
--- a/lib/ember-test-helpers.js
+++ b/lib/ember-test-helpers.js
@@ -3,6 +3,7 @@ import isolatedContainer      from 'ember-test-helpers/isolated-container';
 import TestModule             from 'ember-test-helpers/test-module';
 import TestModuleForComponent from 'ember-test-helpers/test-module-for-component';
 import TestModuleForModel     from 'ember-test-helpers/test-module-for-model';
+import TestModuleForIntegration  from 'ember-test-helpers/test-module-for-integration';
 import { getContext, setContext } from 'ember-test-helpers/test-context';
 import { setResolver } from 'ember-test-helpers/test-resolver';
 
@@ -13,6 +14,7 @@ export {
   TestModule,
   TestModuleForComponent,
   TestModuleForModel,
+  TestModuleForIntegration,
   getContext,
   setContext,
   setResolver

--- a/lib/ember-test-helpers/test-module-for-integration.js
+++ b/lib/ember-test-helpers/test-module-for-integration.js
@@ -17,14 +17,17 @@ export default TestModule.extend({
     context.dispatcher.setup({}, '#ember-testing');
     this.actionHooks = {};
 
-    context.render = function(templateString) {
-      if (Ember.isArray(templateString)) {
-        templateString = templateString.join('');
+    context.render = function(template) {
+      if (Ember.isArray(template)) {
+        template = template.join('');
+      }
+      if (typeof template === 'string') {
+        template = Ember.Handlebars.compile(template);
       }
       self.view = Ember.View.create({
         context: self,
         controller: self,
-        template: Ember.Handlebars.compile(templateString),
+        template: template,
         container: self.container
       });
       Ember.run(function() {

--- a/lib/ember-test-helpers/test-module-for-integration.js
+++ b/lib/ember-test-helpers/test-module-for-integration.js
@@ -7,6 +7,7 @@ export default TestModule.extend({
   init: function(name, description, callbacks) {
     this._super.call(this, name, description, callbacks);
     this.setupSteps.push(this.setupIntegrationHelpers);
+    this.teardownSteps.push(this.teardownView);
   },
 
   setupIntegrationHelpers: function() {
@@ -86,6 +87,15 @@ export default TestModule.extend({
       throw new Error("integration testing template received unexpected action " + actionName);
     }
     hook.apply(this, Array.prototype.slice.call(arguments, 1));
+  },
+
+  teardownView: function() {
+    var view = this.view;
+    if (view) {
+      Ember.run(function() {
+        view.destroy();
+      });
+    }
   }
 
 });

--- a/lib/ember-test-helpers/test-module-for-integration.js
+++ b/lib/ember-test-helpers/test-module-for-integration.js
@@ -25,7 +25,7 @@ export default TestModule.extend({
         template = Ember.Handlebars.compile(template);
       }
       self.view = Ember.View.create({
-        context: self,
+        context: context,
         controller: self,
         template: template,
         container: self.container
@@ -41,12 +41,12 @@ export default TestModule.extend({
 
     context.set = function(key, value) {
       Ember.run(function() {
-        Ember.set(self, key, value);
+        Ember.set(context, key, value);
       });
     };
 
     context.get = function(key) {
-      return Ember.get(self, key);
+      return Ember.get(context, key);
     };
 
     context.on = function(actionName, handler) {

--- a/lib/ember-test-helpers/test-module-for-integration.js
+++ b/lib/ember-test-helpers/test-module-for-integration.js
@@ -1,0 +1,91 @@
+import Ember from 'ember';
+import TestModule from './test-module';
+import { getResolver } from './test-resolver';
+import { getContext, setContext } from './test-context';
+
+export default TestModule.extend({
+  init: function(name, description, callbacks) {
+    this._super.call(this, name, description, callbacks);
+    this.setupSteps.push(this.setupIntegrationHelpers);
+  },
+
+  setupIntegrationHelpers: function() {
+    var self = this;
+    var context = this.context;
+    context.dispatcher = Ember.EventDispatcher.create();
+    context.dispatcher.setup({}, '#ember-testing');
+    this.actionHooks = {};
+
+    context.render = function(templateString) {
+      if (Ember.isArray(templateString)) {
+        templateString = templateString.join('');
+      }
+      self.view = Ember.View.create({
+        context: self,
+        controller: self,
+        template: Ember.Handlebars.compile(templateString),
+        container: self.container
+      });
+      Ember.run(function() {
+        self.view.appendTo('#ember-testing');
+      });
+    };
+
+    context.$ = function() {
+      return self.view.$.apply(self.view, arguments);
+    };
+
+    context.set = function(key, value) {
+      Ember.run(function() {
+        Ember.set(self, key, value);
+      });
+    };
+
+    context.get = function(key) {
+      return Ember.get(self, key);
+    };
+
+    context.on = function(actionName, handler) {
+      self.actionHooks[actionName] = handler;
+    };
+
+  },
+
+  setupContainer: function() {
+    var resolver = getResolver();
+    var namespace = Ember.Object.create({
+      Resolver: { create: function() { return resolver; } }
+    });
+
+    if (Ember.Application.buildRegistry) {
+      var registry;
+      registry = Ember.Application.buildRegistry(namespace);
+      registry.register('component-lookup:main', Ember.ComponentLookup);
+      this.registry = registry;
+      this.container = registry.container();
+    } else {
+      this.container = Ember.Application.buildContainer(namespace);
+      this.container.register('component-lookup:main', Ember.ComponentLookup);
+    }
+  },
+
+  setupContext: function() {
+
+    setContext({
+      container:  this.container,
+      factory: function() {},
+      dispatcher: null
+    });
+
+    this.context = getContext();
+  },
+
+  send: function(actionName) {
+    var hook = this.actionHooks[actionName];
+    if (!hook) {
+      throw new Error("integration testing template received unexpected action " + actionName);
+    }
+    hook.apply(this, Array.prototype.slice.call(arguments, 1));
+  }
+
+});

--- a/tests/test-module-for-integration-test.js
+++ b/tests/test-module-for-integration-test.js
@@ -41,3 +41,8 @@ test('it can handle actions', function() {
   this.$('button').click();
   equal(handlerArg, 42);
 });
+
+test('it accepts precompiled templates', function() {
+  this.render(Ember.Handlebars.compile("<span>Hello</span>"));
+  equal(this.$('span').text(), 'Hello');
+});

--- a/tests/test-module-for-integration-test.js
+++ b/tests/test-module-for-integration-test.js
@@ -1,0 +1,43 @@
+import Ember from 'ember';
+import { TestModuleForIntegration } from 'ember-test-helpers';
+import test from 'tests/test-support/qunit-test';
+import qunitModuleFor from 'tests/test-support/qunit-module-for';
+import { setResolverRegistry } from 'tests/test-support/resolver';
+
+function moduleForIntegration(name, description, callbacks) {
+  var module = new TestModuleForIntegration(name, description, callbacks);
+  qunitModuleFor(module);
+}
+
+moduleForIntegration('Better Integration Tests', {
+  beforeSetup: function() {
+    setResolverRegistry({
+      'template:components/my-component': Ember.Handlebars.compile(
+        '<span>{{name}}</span>'
+      )
+    });
+  }
+});
+
+test('it can render a template', function() {
+  this.render("<span>Hello</span>");
+  equal(this.$('span').text(), 'Hello');
+});
+
+test('it can access the full container', function() {
+  this.set('myColor', 'red');
+  this.render('{{my-component name=myColor}}');
+  equal(this.$('span').text(), 'red');
+  this.set('myColor', 'blue');
+  equal(this.$('span').text(), 'blue');
+});
+
+test('it can handle actions', function() {
+  var handlerArg;
+  this.render('<button {{action "didFoo" 42}} />');
+  this.on('didFoo', function(thing) {
+    handlerArg = thing;
+  });
+  this.$('button').click();
+  equal(handlerArg, 42);
+});


### PR DESCRIPTION
This adds a new kind of test module that fills a gap in the current set of possible tests. So far we have:

 - unit tests that are good for testing algorithmic correctness in isolation.  
 - acceptance tests that are good for testing within a complete application.

But we're missing the ability to integration test a unit smaller than whole-application. This PR adds a new `TestModuleForIntegration` that lets you drive an integration test with a template. I think this is often a more appropriate way to test Ember Components than a unit test, because interesting components tend to have rich dependence on other components.

The included tests illustrate the basic use cases: rendering a template, setting values in its context, and handling its events.