### PR TITLE
Set `registry.normalizeFullName` to `resolver.normalize`.

### DIFF
--- a/lib/ember-test-helpers/isolated-container.js
+++ b/lib/ember-test-helpers/isolated-container.js
@@ -31,24 +31,28 @@ export default function isolatedContainer(fullNames) {
   var resolver = getResolver();
   var container;
 
+  var normalize = function(fullName) {
+    return resolver.normalize(fullName);
+  };
+
   if (Ember.Registry) {
     var registry = new Ember.Registry();
+    registry.normalizeFullName = normalize;
+
     container = registry.container();
     exposeRegistryMethodsWithoutDeprecations(container);
 
   } else {
     container = new Ember.Container();
+
+    //normalizeFullName only exists since Ember 1.9
+    if (Ember.typeOf(container.normalizeFullName) === 'function') {
+      container.normalizeFullName = normalize;
+    } else {
+      container.normalize = normalize;
+    }
   }
 
-  var normalize = function(fullName) {
-    return resolver.normalize(fullName);
-  };
-  //normalizeFullName only exists since Ember 1.9
-  if (Ember.typeOf(container.normalizeFullName) === 'function') {
-    container.normalizeFullName = normalize;
-  } else {
-    container.normalize = normalize;
-  }
   container.optionsForType('component', { singleton: false });
   container.optionsForType('view', { singleton: false });
   container.optionsForType('template', { instantiate: false });


### PR DESCRIPTION
When the `Registry` is present, its `normalizeFullName` method should be
set to the resolver's `normalize` method.

Overriding the normalize methods on the container is ineffective because
they need to proxy to the associated registry's methods.