### PR TITLE
Move integration container logic to TestModule

### DIFF
--- a/lib/ember-test-helpers/test-module-for-integration.js
+++ b/lib/ember-test-helpers/test-module-for-integration.js
@@ -4,6 +4,9 @@ import { getResolver } from './test-resolver';
 import { getContext, setContext } from './test-context';
 
 export default TestModule.extend({
+
+  isIntegration: true,
+
   init: function(name, description, callbacks) {
     this._super.call(this, name, description, callbacks);
     this.setupSteps.push(this.setupIntegrationHelpers);
@@ -53,24 +56,6 @@ export default TestModule.extend({
       self.actionHooks[actionName] = handler;
     };
 
-  },
-
-  setupContainer: function() {
-    var resolver = getResolver();
-    var namespace = Ember.Object.create({
-      Resolver: { create: function() { return resolver; } }
-    });
-
-    if (Ember.Application.buildRegistry) {
-      var registry;
-      registry = Ember.Application.buildRegistry(namespace);
-      registry.register('component-lookup:main', Ember.ComponentLookup);
-      this.registry = registry;
-      this.container = registry.container();
-    } else {
-      this.container = Ember.Application.buildContainer(namespace);
-      this.container.register('component-lookup:main', Ember.ComponentLookup);
-    }
   },
 
   setupContext: function() {

--- a/lib/ember-test-helpers/test-module.js
+++ b/lib/ember-test-helpers/test-module.js
@@ -1,6 +1,8 @@
+import Ember from 'ember';
 import isolatedContainer from './isolated-container';
 import { getContext, setContext } from './test-context';
 import { Klass } from 'klassy';
+import { getResolver } from './test-resolver';
 
 export default Klass.extend({
   init: function(subjectName, description, callbacks) {
@@ -15,6 +17,10 @@ export default Klass.extend({
     this.description = description || subjectName;
     this.name = description || subjectName;
     this.callbacks = callbacks || {};
+
+    if (this.callbacks.integration) {
+      this.isIntegration = callbacks.integration;      
+    }
 
     this.initSubject();
     this.initNeeds();
@@ -97,7 +103,11 @@ export default Klass.extend({
   },
 
   setupContainer: function() {
-    this.container = isolatedContainer(this.needs);
+    if (this.isIntegration) {
+      this._setupIntegratedContainer();
+    } else {
+      this._setupIsolatedContainer();
+    }
   },
 
   setupContext: function() {
@@ -184,6 +194,30 @@ export default Klass.extend({
 
       })(keys[i]);
     }
+  },
+
+
+  _setupIsolatedContainer: function() {
+    this.container = isolatedContainer(this.needs);
+  },
+
+  _setupIntegratedContainer: function() {
+    var resolver = getResolver();
+    var namespace = Ember.Object.create({
+      Resolver: { create: function() { return resolver; } }
+    });
+
+    if (Ember.Application.buildRegistry) {
+      var registry;
+      registry = Ember.Application.buildRegistry(namespace);
+      registry.register('component-lookup:main', Ember.ComponentLookup);
+      this.registry = registry;
+      this.container = registry.container();
+    } else {
+      this.container = Ember.Application.buildContainer(namespace);
+      this.container.register('component-lookup:main', Ember.ComponentLookup);
+    }
   }
+
 });
 

--- a/lib/ember-test-helpers/test-module.js
+++ b/lib/ember-test-helpers/test-module.js
@@ -20,6 +20,7 @@ export default Klass.extend({
 
     if (this.callbacks.integration) {
       this.isIntegration = callbacks.integration;      
+      delete callbacks.integration;
     }
 
     this.initSubject();

--- a/tests/test-module-test.js
+++ b/tests/test-module-test.js
@@ -125,8 +125,31 @@ test("subject's created in a test are destroyed", function() {
   expect(0);
 });
 
-moduleFor('component:x-foo', 'component:x-foo -- `integration: true`', {
+moduleFor('component:x-foo', 'component:x-foo -- without needs or `integration: true`', {
+  beforeSetup: setupRegistry()
+});
+
+test("knows nothing about our non-subject component", function() {
+  var otherComponent = this.container.lookup('component:not-the-subject');
+  equal(null, otherComponent, "We shouldn't know about a non-subject component")
+});
+
+moduleFor('component:x-foo', 'component:x-foo -- when needing another component', {
   beforeSetup: setupRegistry(),
+  needs: ['component:not-the-subject']
+});
+
+test("needs gets us the component we need", function() {
+  var otherComponent = this.container.lookup('component:not-the-subject');
+  ok(otherComponent, "another component can be resolved when it's in our needs array");
+});
+
+moduleFor('component:x-foo', 'component:x-foo -- `integration: true`', {
+  beforeSetup: function() {
+    setupRegistry()
+    ok(!this.callbacks.integration, "integration property should be removed from callbacks");
+    ok(this.isIntegration, "isIntegration should be set when we set `integration: true` in callbacks");
+  },
   integration: true
 });
 

--- a/tests/test-module-test.js
+++ b/tests/test-module-test.js
@@ -10,7 +10,8 @@ function moduleFor(fullName, description, callbacks) {
 
 function setupRegistry() {
   setResolverRegistry({
-    'component:x-foo': Ember.Component.extend()
+    'component:x-foo':           Ember.Component.extend(),
+    'component:not-the-subject': Ember.Component.extend()
   });
 }
 
@@ -122,4 +123,14 @@ moduleFor('component:x-foo', 'component:x-foo -- uncreated subjects do not error
 
 test("subject's created in a test are destroyed", function() {
   expect(0);
+});
+
+moduleFor('component:x-foo', 'component:x-foo -- `integration: true`', {
+  beforeSetup: setupRegistry(),
+  integration: true
+});
+
+test("needs is not needed (pun intended) when integration is true", function() {
+  var otherComponent = this.container.lookup('component:not-the-subject');
+  ok(otherComponent, 'another component can be resolved when integration is true');
 });


### PR DESCRIPTION
This moves the integration logic up into TestModule, so that you can specify:

```
  integration: true
```

And you'll be able to resolve other units in your application without adding them to `needs`.

(thanks @rwjblue!)