### PR TITLE
Render for tagless component should not call `view.$()`

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -25,7 +25,7 @@
   ],
   "dependencies": {
     "klassy": "cerebris/klassy.js#0.1.0",
-    "ember": "^1.10.0"
+    "ember": "1.11.0-beta.5"
   },
   "devDependencies": {
     "qunit": "^1.15.0",

--- a/lib/ember-test-helpers/test-module-for-component.js
+++ b/lib/ember-test-helpers/test-module-for-component.js
@@ -44,7 +44,9 @@ export default TestModule.extend({
         });
       });
 
-      return view.$();
+      if (view.tagName !== '') {
+        return view.$();
+      }
     };
 
     this.callbacks.append = function() {

--- a/tests/test-module-for-component-test.js
+++ b/tests/test-module-for-component-test.js
@@ -39,11 +39,16 @@ var BoringColor = Ember.Component.extend({
   }
 });
 
+var TaglessThing = Ember.Component.extend({
+  tagName: ''
+});
+
 function setupRegistry() {
   setResolverRegistry({
     'component:x-foo': Ember.Component.extend(),
     'component:pretty-color': PrettyColor,
     'component:boring-color': BoringColor,
+    'component:tagless-thing': TaglessThing,
     'template:components/pretty-color': Ember.Handlebars.compile('Pretty Color: <span class="color-name">{{name}}</span>'),
     'controller:color': ColorController
   });
@@ -230,4 +235,32 @@ moduleForComponent('boring-color', 'component:boring-color -- still in DOM in wi
 test("className", function(){
   expect(1)
   // the assertion is in the willDestroyElement() hook of the component
+});
+
+moduleForComponent('tagless-thing', 'component:tagless-thing -- this.render', {
+  beforeSetup: function() {
+    setupRegistry();
+  }
+});
+
+test("render returns undefined, does not call component.$()", function(){
+  expect(2);
+
+  var error = null;
+  var result;
+
+  try {
+    result = this.render();
+  } catch (e) {
+    error = e;
+  }
+
+  if (error) {
+    ok(false, 'render failed with error: ' + error.message);
+  } else {
+    ok(true, 'render did not error');
+  }
+
+  ok(result === undefined,
+     'this.render() returns undefined');
 });


### PR DESCRIPTION
In Ember 1.11, calling `this.$()` for a tagless component (`tagName === ''`), ember will [throw an assertion complaining](https://github.com/emberjs/ember.js/blob/06e41ad7ccd28558dd4e651aa070bc06f7757821/packages/ember-views/lib/views/view.js#L943-L946).

`moduleForComponent` always calls `this.$()` in its `render` callback, so in Ember 1.11 you can't effectively test the rendering of tagless components.

This adds an isolated commit with a failing test (and ember upgraded to 1.11.0-beta.5) and a second commit fixing that test.

I'm not sure if this is the best solution. It makes `this.render` simply return `undefined` for tagless components, which may be more surprising for a user than the assertion message that ember will raise.

Perhaps the `render` callback's call signature can change to include a `shouldGetElement` boolean instead?
So for a tagless component you would call `this.render(false)` in your test. And in that case `render` could raise its own assertion when called without `false` for a tagless component.

Alternatively, could use a heuristic to just find the first child of the ContainerView in the `#ember-testing` div, so that `this.render` always returns an element.