### PR TITLE
[breaking] Remove `view.$()` call in `render()` of module for component

### DIFF
--- a/lib/ember-test-helpers/test-module-for-component.js
+++ b/lib/ember-test-helpers/test-module-for-component.js
@@ -45,8 +45,8 @@ export default TestModule.extend({
     };
 
     this.callbacks.append = function() {
-      Ember.deprecate('this.append() is deprecated. Please use this.render() instead.');
-      return this.callbacks.render();
+      Ember.deprecate('this.append() is deprecated. Please use this.render() or this.$() instead.');
+      return context.$();
     };
 
     context.$ = function() {

--- a/lib/ember-test-helpers/test-module-for-component.js
+++ b/lib/ember-test-helpers/test-module-for-component.js
@@ -31,11 +31,10 @@ export default TestModule.extend({
 
     this.callbacks.render = function() {
       var containerView = Ember.ContainerView.create({container: container});
-      var view = Ember.run(function(){
+      Ember.run(function(){
         var subject = context.subject();
         containerView.pushObject(subject);
         containerView.appendTo('#ember-testing');
-        return subject;
       });
 
       _this.teardownSteps.unshift(function() {
@@ -43,8 +42,6 @@ export default TestModule.extend({
           Ember.tryInvoke(containerView, 'destroy');
         });
       });
-
-      return view.$();
     };
 
     this.callbacks.append = function() {
@@ -53,14 +50,10 @@ export default TestModule.extend({
     };
 
     context.$ = function() {
-      var $view = this.render();
+      this.render();
       var subject = this.subject();
 
-      if (arguments.length){
-        return subject.$.apply(subject, arguments);
-      } else {
-        return $view;
-      }
+      return subject.$.apply(subject, arguments);
     };
   }
 });

--- a/lib/ember-test-helpers/test-module.js
+++ b/lib/ember-test-helpers/test-module.js
@@ -90,6 +90,7 @@ export default Klass.extend({
     this.invokeSteps(this.contextualizedTeardownSteps, this.context);
     this.invokeSteps(this.teardownSteps);
     this.cache = null;
+    this.cachedCalls = null;
   },
 
   invokeSteps: function(steps, _context) {
@@ -177,6 +178,7 @@ export default Klass.extend({
     var factory   = context.factory;
 
     this.cache = this.cache || {};
+    this.cachedCalls = this.cachedCalls || {};
 
     var keys = Ember.keys(callbacks);
 
@@ -184,11 +186,12 @@ export default Klass.extend({
       (function(key) {
 
         context[key] = function(options) {
-          if (_this.cache[key]) { return _this.cache[key]; }
+          if (_this.cachedCalls[key]) { return _this.cache[key]; }
 
           var result = callbacks[key].call(_this, options, factory());
 
           _this.cache[key] = result;
+          _this.cachedCalls[key] = true;
 
           return result;
         };

--- a/tests/test-module-for-component-test.js
+++ b/tests/test-module-for-component-test.js
@@ -51,8 +51,17 @@ function setupRegistry() {
 
 ///////////////////////////////////////////////////////////////////////////////
 
+var originalDeprecate;
 moduleForComponent('x-foo', {
   needs: ['controller:color'],
+
+  setup: function() {
+    originalDeprecate = Ember.deprecate;
+  },
+
+  teardown: function() {
+    Ember.deprecate = originalDeprecate;
+  },
 
   beforeSetup: function() {
     setupRegistry();
@@ -68,13 +77,22 @@ test('renders', function() {
 });
 
 test('append', function() {
-  expect(2);
-  var component = this.subject();
+  expect(4);
+
+  var deprecations = [];
+  var $el;
+  var component;
+
+  // capture all deprecations so they can be checked later
+  Ember.deprecate = function(message) {
+    deprecations.push(message);
+  };
+  component = this.subject();
   equal(component._state, 'preRender');
-  this.append();
+  $el = this.append();
   equal(component._state, 'inDOM');
-  // TODO - is there still a way to check deprecationWarnings?
-//  ok(Ember.A(Ember.deprecationWarnings).contains('this.append() is deprecated. Please use this.render() instead.'));
+  ok($el && $el.length, 'append returns $el');
+  ok(Ember.A(deprecations).contains('this.append() is deprecated. Please use this.render() or this.$() instead.'));
 });
 
 test('yields', function() {


### PR DESCRIPTION
from #26 

This PR makes two changes:

  * use a `cachedCalls` object internally in TestModule to track whether a given callback has been called. Previously, the code only did a check on the result (in `this.cache[key]`), which means that a callback that returns a falsy value will (incorrectly, it seems) be called multiple times. This seemed likely to result in inconsistent behavior. (This change is necessary for the following change)
  * change `this.callbacks.render` to *not* return anything. It simply renders the component. This is a _breaking change_. Previously, `render` would return the rendered view's `this.$()` method, but this is problematic because there are cases where a view's `$()` method should not be called. Specifically, in Ember 1.11.0.beta-5, calling `this.$()` on a tagless component (where `tagName = ''`) will result in a failed assertion: ["You cannot access this.$() on a component with `tagName: \'\'` specified."](https://github.com/emberjs/ember.js/blob/06e41ad7ccd28558dd4e651aa070bc06f7757821/packages/ember-views/lib/views/view.js#L943-L946), making it difficult-to-impossible to test such a component in a unit test. 

Test users can still call `this.$()` to get the jquery-wrapped element (in cases where that makes sense — if the component is tagless they will still get the failed assert mentioned above)

cc @rwjblue @mixonic