### PR TITLE
Asynchronous module hooks

### DIFF
--- a/lib/ember-test-helpers/test-module.js
+++ b/lib/ember-test-helpers/test-module.js
@@ -81,16 +81,21 @@ export default Klass.extend({
   },
 
   setup: function() {
-    this.invokeSteps(this.setupSteps);
-    this.contextualizeCallbacks();
-    this.invokeSteps(this.contextualizedSetupSteps, this.context);
+    var self = this;
+    return self.invokeSteps(self.setupSteps).then(function() {
+      self.contextualizeCallbacks();
+      return self.invokeSteps(self.contextualizedSetupSteps, self.context);
+    });
   },
 
   teardown: function() {
-    this.invokeSteps(this.contextualizedTeardownSteps, this.context);
-    this.invokeSteps(this.teardownSteps);
-    this.cache = null;
-    this.cachedCalls = null;
+    var self = this;
+    return self.invokeSteps(self.contextualizedTeardownSteps, self.context).then(function() {
+      return self.invokeSteps(self.teardownSteps);
+    }).then(function() {
+      self.cache = null;
+      self.cachedCalls = null;
+    });
   },
 
   invokeSteps: function(steps, _context) {
@@ -98,10 +103,16 @@ export default Klass.extend({
     if (!context) {
       context = this;
     }
-
-    for (var i = 0, l = steps.length; i < l; i++) {
-      steps[i].call(context);
+    steps = steps.slice();
+    function nextStep() {
+      var step = steps.shift();
+      if (step) {
+        return Ember.RSVP.resolve(step.call(context)).then(nextStep);
+      } else {
+        return Ember.RSVP.resolve();
+      }
     }
+    return nextStep();
   },
 
   setupContainer: function() {

--- a/tests/test-support/qunit-module-for.js
+++ b/tests/test-support/qunit-module-for.js
@@ -1,10 +1,12 @@
 export default function qunitModuleFor(module) {
   QUnit.module(module.name, {
-    setup: function() {
-      module.setup();
+    setup: function(assert) {
+      var done = assert.async();
+      module.setup()['finally'](done);
     },
-    teardown: function() {
-      module.teardown();
+    teardown: function(assert) {
+      var done = assert.async();
+      module.teardown()['finally'](done);
     }
   });
 }


### PR DESCRIPTION
This makes it possible for module hooks to be asynchronous.

My immediate use case for this is that the only way to do an asynchronous action in a mocha `beforeEach` hook is to return a promise from said hook.

I'm submitting corresponding PRs to ember-mocha and ember-qunit.