### PR TITLE
Register some built in Ember Data objects if ED exists on the page.

### DIFF
--- a/lib/ember-test-helpers/isolated-container.js
+++ b/lib/ember-test-helpers/isolated-container.js
@@ -66,6 +66,18 @@ export default function isolatedContainer(fullNames) {
   container.register('view:select', Ember.Select);
   container.register('route:basic', Ember.Route, { instantiate: false });
 
+  var globalContext = typeof global === 'object' && global || self;
+  if (globalContext.DS) {
+    var DS = globalContext.DS;
+    registry.register('transform:boolean', DS.BooleanTransform);
+    registry.register('transform:date', DS.DateTransform);
+    registry.register('transform:number', DS.NumberTransform);
+    registry.register('transform:string', DS.StringTransform);
+    registry.register('serializer:-default', DS.JSONSerializer);
+    registry.register('serializer:-rest', DS.RESTSerializer);
+    registry.register('adapter:-rest', DS.RESTAdapter);
+  }
+
   for (var i = fullNames.length; i > 0; i--) {
     var fullName = fullNames[i - 1];
     var normalizedFullName = resolver.normalize(fullName);


### PR DESCRIPTION
This will make it easier to test serializers without having to know
about the transform's Ember Data registers under the hood.


Not sure the best way to test this without adding Ember Data as a dependency.