### PR TITLE
Register `view:-outlet`. Fixes #36

### DIFF
--- a/lib/ember-test-helpers/isolated-container.js
+++ b/lib/ember-test-helpers/isolated-container.js
@@ -64,6 +64,7 @@ export default function isolatedContainer(fullNames) {
   container.register('view:default', Ember._MetamorphView);
   container.register('view:toplevel', Ember.View.extend());
   container.register('view:select', Ember.Select);
+  container.register('view:-outlet', Ember.OutletView);
   container.register('route:basic', Ember.Route, { instantiate: false });
 
   var globalContext = typeof global === 'object' && global || self;

--- a/tests/test-module-test.js
+++ b/tests/test-module-test.js
@@ -157,3 +157,20 @@ test("needs is not needed (pun intended) when integration is true", function() {
   var otherComponent = this.container.lookup('component:not-the-subject');
   ok(otherComponent, 'another component can be resolved when integration is true');
 });
+
+moduleFor('view:with-outlet', 'view:with-outlet does not error', {
+  beforeSetup: function() {
+    var WithOutletView = Ember.View.extend({
+      template: Ember.Handlebars.compile('{{outlet}}')
+    });
+    setResolverRegistry({'view:with-outlet': WithOutletView});
+  }
+});
+
+test("a view with an outlet in its template can be rendered", function() {
+  expect(0);
+  var view = this.subject();
+  Ember.run(function() {
+    view.appendTo("#ember-testing");
+  });
+});


### PR DESCRIPTION
This fixes a regression for views that have an outlet in their templates
and are rendered into the testing container.