### PR TITLE
Delegate to DS._setupContainer when available to register service:store

### DIFF
--- a/lib/ember-test-helpers/isolated-container.js
+++ b/lib/ember-test-helpers/isolated-container.js
@@ -69,13 +69,17 @@ export default function isolatedContainer(fullNames) {
   var globalContext = typeof global === 'object' && global || self;
   if (globalContext.DS) {
     var DS = globalContext.DS;
-    container.register('transform:boolean', DS.BooleanTransform);
-    container.register('transform:date', DS.DateTransform);
-    container.register('transform:number', DS.NumberTransform);
-    container.register('transform:string', DS.StringTransform);
-    container.register('serializer:-default', DS.JSONSerializer);
-    container.register('serializer:-rest', DS.RESTSerializer);
-    container.register('adapter:-rest', DS.RESTAdapter);
+    if (DS._setupContainer) {
+      DS._setupContainer(container);
+    } else {
+      container.register('transform:boolean', DS.BooleanTransform);
+      container.register('transform:date', DS.DateTransform);
+      container.register('transform:number', DS.NumberTransform);
+      container.register('transform:string', DS.StringTransform);
+      container.register('serializer:-default', DS.JSONSerializer);
+      container.register('serializer:-rest', DS.RESTSerializer);
+      container.register('adapter:-rest', DS.RESTAdapter);
+    }
   }
 
   for (var i = fullNames.length; i > 0; i--) {

--- a/lib/ember-test-helpers/test-module-for-model.js
+++ b/lib/ember-test-helpers/test-module-for-model.js
@@ -16,12 +16,6 @@ export default TestModule.extend({
     var callbacks = this.callbacks;
     var modelName = this.modelName;
 
-    if (DS._setupContainer) {
-      DS._setupContainer(container);
-    } else {
-      container.register('store:main', DS.Store);
-    }
-
     var adapterFactory = container.lookupFactory('adapter:application');
     if (!adapterFactory) {
       container.register('adapter:application', DS.FixtureAdapter);


### PR DESCRIPTION
This pr will automatically register the Store as a service for users running. Ember Data beta.16.

The one gotcha is if the user declares `service:store` in their needs. For Example: 

```js
moduleForComponent('actor-table', {
  // specify the other units that are required for this test
  needs: ['service:store']
});
```

The test will blow up with this error. `Uncaught TypeError: Attempting to register an unknown factory: 'service:store'`, because this code https://github.com/switchfly/ember-test-helpers/blob/master/lib/ember-test-helpers/isolated-container.js#L81-L85 attempts to pull in a `service:store` from `app/services/store.js` which likely doesn't exist.

