### PR TITLE
Test coverage for `render` during component integration test setup

### DIFF
--- a/tests/test-module-for-integration-test.js
+++ b/tests/test-module-for-integration-test.js
@@ -63,3 +63,47 @@ test('it accepts precompiled templates', function() {
   this.render(Ember.Handlebars.compile("<span>Hello</span>"));
   equal(this.$('span').text(), 'Hello');
 });
+
+test('it supports DOM events', function() {
+  setResolverRegistry({
+    'component:my-component': Ember.Component.extend({
+      value: 0,
+      layout: Ember.Handlebars.compile(`
+        <span class='target'>Click to increment!</span>
+        <span class='value'>{{value}}</span>
+      `),
+      incrementOnClick: Ember.on('click', function() {
+        this.incrementProperty('value');
+      })
+    })
+  });
+  this.render('{{my-component}}');
+  this.$('.target').click();
+  equal(this.$('.value').text(), '1');
+});
+
+moduleForComponent('Component Integration Tests: render during setup', {
+  integration: true,
+  beforeSetup: function() {
+    setResolverRegistry({
+      'component:my-component': Ember.Component.extend({
+        value: 0,
+        layout: Ember.Handlebars.compile(`
+          <span class='target'>Click to increment!</span>
+          <span class='value'>{{value}}</span>
+        `),
+        incrementOnClick: Ember.on('click', function() {
+          this.incrementProperty('value');
+        })
+      })
+    });
+  },
+  setup() {
+    this.render('{{my-component}}');
+  }
+});
+
+test('it has working events', function() {
+  this.$('.target').click();
+  equal(this.$('.value').text(), '1');
+});

--- a/tests/test-support/qunit-test.js
+++ b/tests/test-support/qunit-test.js
@@ -1,14 +1,9 @@
 import { getContext } from 'ember-test-helpers';
 
-function resetViews() {
-  Ember.View.views = {};
-}
-
 export default function test(testName, callback) {
   function wrapper() {
     var context = getContext();
 
-    resetViews();
     var result = callback.call(context);
 
     function failTestOnPromiseRejection(reason) {


### PR DESCRIPTION
Assuming [this PR](https://github.com/rwjblue/ember-qunit/pull/167) lands in ember-qunit, we can support  the use of `this.render` during component integration test setup hooks, as discussed in the comments to https://github.com/switchfly/ember-test-helpers/pull/38.

This PR updates the embedded copy of ember-qunit's test function to match that change, and adds test coverage.