### PR TITLE
Add container items required for Glimmer.

### DIFF
--- a/lib/ember-test-helpers/isolated-container.js
+++ b/lib/ember-test-helpers/isolated-container.js
@@ -67,6 +67,16 @@ export function isolatedRegistry(fullNames) {
   container.register('view:select', Ember.Select);
   container.register('route:basic', Ember.Route, { instantiate: false });
 
+  // added in Glimmer
+  container.register('component:-link-to', Ember.LinkView);
+  container.register('component:-text-field', Ember.TextField);
+  container.register('component:-text-area', Ember.TextArea);
+  container.register('component:-checkbox', Ember.Checkbox);
+
+  if (Ember._LegacyEachView) {
+    container.register('view:-legacy-each', Ember._LegacyEachView);
+  }
+
   var globalContext = typeof global === 'object' && global || self;
   if (globalContext.DS) {
     var DS = globalContext.DS;


### PR DESCRIPTION
This is getting pretty annoying. We need a *much* better way to deal with these default/fallback container items, but we also need tests to work in Glimmer-land.  So, grrr, but YOLO...