### PR TITLE
Allow missing arguments for `moduleForComponent`.

### DIFF
--- a/lib/ember-test-helpers/test-module-for-component.js
+++ b/lib/ember-test-helpers/test-module-for-component.js
@@ -6,8 +6,10 @@ export default TestModule.extend({
   init: function(componentName, description, callbacks) {
     // Allow `description` to be omitted
     if (!callbacks && typeof description === 'object') {
-      callbacks = description || {};
+      callbacks = description;
       description = null;
+    } else if (!callbacks && !description) {
+      callbacks = {};
     }
 
     this.componentName = componentName;

--- a/tests/test-module-for-component-test.js
+++ b/tests/test-module-for-component-test.js
@@ -252,3 +252,21 @@ test("className", function(){
   expect(1)
   // the assertion is in the willDestroyElement() hook of the component
 });
+
+var testModule;
+module('moduleForComponent: can be invoked with only the component name', {
+  beforeEach: function(assert) {
+    var done = assert.async();
+    testModule = new TestModuleForComponent('pretty-color');
+    testModule.setup()['finally'](done);
+  },
+
+  afterEach: function(assert) {
+    var done = assert.async();
+    testModule.teardown()['finally'](done);
+  }
+});
+
+test('it allows missing callbacks', function() {
+  ok(true, 'no errors are thrown');
+});


### PR DESCRIPTION
Fixes #47.