### PR TITLE
Adds test for presence of store using integration: true in moduleForModel

### DIFF
--- a/tests/test-module-for-model-test.js
+++ b/tests/test-module-for-model-test.js
@@ -146,3 +146,21 @@ test('ApplicationAdapter is registered for model', function() {
   ok(store.adapterFor(model.constructor) instanceof ApplicationAdapter);
   ok(!(store.adapterFor(model.constructor) instanceof WhazzitAdapter));
 });
+
+///////////////////////////////////////////////////////////////////////////////
+
+moduleForModel('whazzit', 'model:whazzit when using integration:true', {
+
+  integration: true,
+
+  beforeSetup: function() {
+    setupRegistry();
+  }
+
+});
+
+test('the store still exists', function() {
+  var store = this.store();
+  equal(123, Ember.inspect(store));
+  ok(store instanceof DS.Store);
+});


### PR DESCRIPTION
Hi team!

I'm having a bit of trouble with the latest version of `ember-test-helpers`. It looks like there was a regression with `integration: true` somewhere that means `container.lookup("store:main")` is returning undefined. :crying_cat_face: 

I've added a failing test for this, and I'm working on a fix at the moment (although any pointers as to the right direction are greatly appreciated!)

Thanks,

Nik

(ping @rwjblue :stuck_out_tongue_closed_eyes:) 