### PR TITLE
Provide better context for `subject()` deprecation

### DIFF
--- a/lib/ember-test-helpers/test-module-for-component.js
+++ b/lib/ember-test-helpers/test-module-for-component.js
@@ -46,7 +46,7 @@ export default TestModule.extend({
       this.setupSteps.push(this.setupComponentUnitTest);
     } else {
       this.callbacks.subject = function() {
-        throw new Error("component integration tests do not support `subject()`.");
+        throw new Error("component integration tests do not support `subject()`. Instead, render the component as if it were HTML: `this.render('<my-component foo=true>');`. For more information, read: http://guides.emberjs.com/v2.2.0/testing/testing-components/");
       };
       this.setupSteps.push(this.setupComponentIntegrationTest);
       this.teardownSteps.unshift(this.teardownComponent);


### PR DESCRIPTION
The outcome of [#38][38] is undocumented. 

Raising a deprecation warning for calls to `this.subject` is a good start, 
but could be improved greatly.

[38]: https://github.com/switchfly/ember-test-helpers/pull/38