### PR TITLE
Compatibility with Ember 1.13+

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -42,7 +42,7 @@ main = concat(main, {
 var vendor = concat('bower_components', {
   inputFiles: ['jquery/dist/jquery.js',
                'ember/ember-template-compiler.js',
-               'ember/ember.js',
+               'ember/ember.debug.js',
                'ember-data/ember-data.js'],
   outputFile: '/assets/vendor.js'
 });

--- a/bower.json
+++ b/bower.json
@@ -25,7 +25,7 @@
   ],
   "dependencies": {
     "klassy": "cerebris/klassy.js#0.1.0",
-    "ember": "^1.10.0"
+    "ember": "^1.13.0"
   },
   "devDependencies": {
     "qunit": "^1.15.0",
@@ -33,6 +33,6 @@
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "rwjblue/ember-cli-test-loader#0.0.4",
     "jquery": "~2.1.1",
-    "ember-data": "~1.0.0-beta.10"
+    "ember-data": "~1.0.0-beta.19.2"
   }
 }

--- a/lib/ember-test-helpers/test-module-for-component.js
+++ b/lib/ember-test-helpers/test-module-for-component.js
@@ -91,7 +91,7 @@ export default TestModule.extend({
   },
 
   setupComponentIntegrationTest: function() {
-    var self = this;
+    var module = this;
     var context = this.context;
     context.dispatcher = Ember.EventDispatcher.create();
     context.dispatcher.setup({}, '#ember-testing');
@@ -107,19 +107,20 @@ export default TestModule.extend({
       if (typeof template === 'string') {
         template = Ember.Handlebars.compile(template);
       }
-      self.component = Ember.View.create({
-        context: context,
-        controller: self,
-        template: template,
-        container: self.container
+      module.component = Ember.Component.create({
+        layout: template,
+        container: module.container
       });
+      module.component.set('context' ,context);
+      module.component.set('controller', module);
+
       Ember.run(function() {
-        self.component.appendTo('#ember-testing');
+        module.component.appendTo('#ember-testing');
       });
     };
 
     context.$ = function() {
-      return self.component.$.apply(self.component, arguments);
+      return module.component.$.apply(module.component, arguments);
     };
 
     context.set = function(key, value) {
@@ -133,7 +134,7 @@ export default TestModule.extend({
     };
 
     context.on = function(actionName, handler) {
-      self.actionHooks[actionName] = handler;
+      module.actionHooks[actionName] = handler;
     };
 
   },

--- a/tests/test-module-for-component-test.js
+++ b/tests/test-module-for-component-test.js
@@ -13,7 +13,7 @@ var PrettyColor = Ember.Component.extend({
   classNames: ['pretty-color'],
   attributeBindings: ['style'],
   style: function(){
-    return 'color: ' + this.get('name') + ';';
+    return new Ember.Handlebars.SafeString('color: ' + this.get('name') + ';');
   }.property('name')
 });
 
@@ -114,65 +114,6 @@ test('can lookup components in its layout', function() {
   equal(component._state, 'inDOM');
 });
 
-test('can lookup array controllers in its layout', function() {
-  expect(1);
-  var component = this.subject({
-    colors: ['red', 'green', 'blue'],
-    layout: Ember.Handlebars.compile("{{#each colors itemController='color'}}{{hexa}}{{/each}}")
-  });
-  this.render();
-  equal(component._state, 'inDOM');
-});
-
-test('can lookup object controllers in its layout', function() {
-  expect(1);
-  var component = this.subject({
-    colors: ['red', 'green', 'blue'],
-    layout: Ember.Handlebars.compile("{{#each colors itemController='object'}}{{this}}{{/each}}")
-  });
-  this.render();
-  equal(component._state, 'inDOM');
-});
-
-test('can lookup basic controllers in its layout', function() {
-  expect(1);
-  var component = this.subject({
-    colors: ['red', 'green', 'blue'],
-    layout: Ember.Handlebars.compile("{{#each colors itemController='basic'}}{{this}}{{/each}}")
-  });
-  this.render();
-  equal(component._state, 'inDOM');
-});
-
-test('can lookup Ember.Select in its layout', function() {
-  expect(1);
-  var component = this.subject({
-    colors: ['red', 'green', 'blue'],
-    layout: Ember.Handlebars.compile("{{view 'select'}}")
-  });
-  this.render();
-  equal(component._state, 'inDOM');
-});
-
-test('can lookup default Ember.Views in its layout', function() {
-  expect(1);
-  var component = this.subject({
-    colors: ['red', 'green', 'blue'],
-    layout: Ember.Handlebars.compile("{{view id='foo'}}")
-  });
-  this.render();
-  equal(component.$('#foo').length, 1, 'expected to find `foo` element');
-});
-
-test('can lookup toplevel Ember.Views in its layout', function() {
-  expect(1);
-  var component = this.subject({
-    colors: ['red', 'green', 'blue'],
-    layout: Ember.Handlebars.compile("{{view 'toplevel'}}")
-  });
-  this.render();
-  equal(component._state, 'inDOM');
-});
 
 test('clears out views from test to test', function() {
   expect(1);
@@ -257,7 +198,7 @@ var testModule;
 module('moduleForComponent: can be invoked with only the component name', {
   beforeEach: function(assert) {
     var done = assert.async();
-    testModule = new TestModuleForComponent('pretty-color');
+    testModule = new TestModuleForComponent('pretty-color', { unit: true });
     testModule.setup()['finally'](done);
   },
 
@@ -275,7 +216,7 @@ var testModule;
 module('moduleForComponent: can be invoked with the component name and description', {
   beforeEach: function(assert) {
     var done = assert.async();
-    testModule = new TestModuleForComponent('pretty-color', 'PrettyColor');
+    testModule = new TestModuleForComponent('pretty-color', 'PrettyColor', { unit: true });
     testModule.setup()['finally'](done);
   },
 

--- a/tests/test-module-for-integration-test.js
+++ b/tests/test-module-for-integration-test.js
@@ -63,3 +63,47 @@ test('it accepts precompiled templates', function() {
   this.render(Ember.Handlebars.compile("<span>Hello</span>"));
   equal(this.$('span').text(), 'Hello');
 });
+
+test('it supports DOM events', function() {
+  setResolverRegistry({
+    'component:my-component': Ember.Component.extend({
+      value: 0,
+      layout: Ember.Handlebars.compile(`
+        <span class='target'>Click to increment!</span>
+        <span class='value'>{{value}}</span>
+      `),
+      incrementOnClick: Ember.on('click', function() {
+        this.incrementProperty('value');
+      })
+    })
+  });
+  this.render('{{my-component}}');
+  this.$('.target').click();
+  equal(this.$('.value').text(), '1');
+});
+
+moduleForComponent('Component Integration Tests: render during setup', {
+  integration: true,
+  beforeSetup: function() {
+    setResolverRegistry({
+      'component:my-component': Ember.Component.extend({
+        value: 0,
+        layout: Ember.Handlebars.compile(`
+          <span class='target'>Click to increment!</span>
+          <span class='value'>{{value}}</span>
+        `),
+        incrementOnClick: Ember.on('click', function() {
+          this.incrementProperty('value');
+        })
+      })
+    });
+  },
+  setup() {
+    this.render('{{my-component}}');
+  }
+});
+
+test('it has working events', function() {
+  this.$('.target').click();
+  equal(this.$('.value').text(), '1');
+});

--- a/tests/test-module-for-integration-test.js
+++ b/tests/test-module-for-integration-test.js
@@ -68,10 +68,7 @@ test('it supports DOM events', function() {
   setResolverRegistry({
     'component:my-component': Ember.Component.extend({
       value: 0,
-      layout: Ember.Handlebars.compile(`
-        <span class='target'>Click to increment!</span>
-        <span class='value'>{{value}}</span>
-      `),
+      layout: Ember.Handlebars.compile("<span class='target'>Click to increment!</span><span class='value'>{{value}}</span>"),
       incrementOnClick: Ember.on('click', function() {
         this.incrementProperty('value');
       })
@@ -88,17 +85,14 @@ moduleForComponent('Component Integration Tests: render during setup', {
     setResolverRegistry({
       'component:my-component': Ember.Component.extend({
         value: 0,
-        layout: Ember.Handlebars.compile(`
-          <span class='target'>Click to increment!</span>
-          <span class='value'>{{value}}</span>
-        `),
+        layout: Ember.Handlebars.compile("<span class='target'>Click to increment!</span><span class='value'>{{value}}</span>"),
         incrementOnClick: Ember.on('click', function() {
           this.incrementProperty('value');
         })
       })
     });
   },
-  setup() {
+  setup: function() {
     this.render('{{my-component}}');
   }
 });

--- a/tests/test-support/qunit-test.js
+++ b/tests/test-support/qunit-test.js
@@ -1,14 +1,9 @@
 import { getContext } from 'ember-test-helpers';
 
-function resetViews() {
-  Ember.View.views = {};
-}
-
 export default function test(testName, callback) {
   function wrapper() {
     var context = getContext();
 
-    resetViews();
     var result = callback.call(context);
 
     function failTestOnPromiseRejection(reason) {

--- a/tests/test-support/resolver.js
+++ b/tests/test-support/resolver.js
@@ -12,7 +12,7 @@ var Resolver = Ember.DefaultResolver.extend({
   }
 });
 
-var resolver = Resolver.create({registry: {}});
+var resolver = Resolver.create({registry: {}, namespace: {}});
 setResolver(resolver);
 
 export function setResolverRegistry(registry) {


### PR DESCRIPTION
This cleans up deprecations for use with Ember 1.13+, plus one small
private API break (the changed `Resolver.create()` call).

The removed tests were all testing container resolution of things that
are deprecated. There is still coverage for container resolution of
Components, which should be sufficient.

The test suite still emits a several deprecations, but they are all
coming from Ember Data and will need to get fixed there.

I worked on this PR with @stefanpenner.

This PR also supersedes #42, which was ready to go and relevant.