### PR TITLE
Don't replace Ember's internal view:toplevel

### DIFF
--- a/lib/ember-test-helpers/build-registry.js
+++ b/lib/ember-test-helpers/build-registry.js
@@ -33,7 +33,9 @@ export default function(resolver) {
   function register(name, factory) {
     var thingToRegisterWith = registry || container;
 
-    thingToRegisterWith.register(name, factory);
+    if (!container.lookupFactory(name)) {
+      thingToRegisterWith.register(name, factory);
+    }
   }
 
   if (Ember.Application.buildRegistry) {

--- a/tests/test-module-for-integration-test.js
+++ b/tests/test-module-for-integration-test.js
@@ -101,3 +101,25 @@ test('it has working events', function() {
   this.$('.target').click();
   equal(this.$('.value').text(), '1');
 });
+
+var origDeprecate;
+moduleForComponent('Component Integration Tests: implicit views are not deprecated', {
+  integration: true,
+  setup: function () {
+    origDeprecate = Ember.deprecate;
+    Ember.deprecate = function(msg, check) {
+      if (!check) {
+        throw new Error("unexpected deprecation: " + msg);
+      }
+    };
+  },
+  teardown: function () {
+    Ember.deprecate = origDeprecate;
+  }
+});
+
+test('the toplevel view is not deprecated', function () {
+  expect(0);
+  (this.registry || this.container).register('component:my-toplevel', this.container.lookupFactory('view:toplevel'));
+  this.render("{{my-toplevel}}");
+});


### PR DESCRIPTION
This fixes another deprecation in Ember 1.13. ember-test-helpers was
replacing `view:toplevel` with `Ember.View`, which is deprecated. We
should instead just leave `view:toplevel` alone, because the internal
version is not deprecated.