### PR TITLE
Add a test for {{component}} helper

### DIFF
--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,15 +1,15 @@
 module.exports = {
   scenarios: [
     {
-      name: 'ember-1.10.0',
+      name: 'ember-1.11.3',
       dependencies: {
-        "ember": "1.10.0"
+        "ember": "1.11.3"
       }
     },
     {
-      name: 'ember-1.11.1',
+      name: 'ember-1.12.1',
       dependencies: {
-        "ember": "1.11.1"
+        "ember": "1.12.1"
       }
     },
     {

--- a/tests/test-module-for-component-test.js
+++ b/tests/test-module-for-component-test.js
@@ -114,6 +114,15 @@ test('can lookup components in its layout', function() {
   equal(component._state, 'inDOM');
 });
 
+test('can use the component keyword in its layout', function() {
+  expect(1);
+  var component = this.subject({
+    colors: ['red', 'green', 'blue'],
+    layout: Ember.Handlebars.compile("{{component 'x-foo'}}")
+  });
+  this.render();
+  equal(component._state, 'inDOM');
+});
 
 test('clears out views from test to test', function() {
   expect(1);


### PR DESCRIPTION
This replaces the `{{view}}` helper test coverage that I removed in #60 with a test of the `{{component}}` helper instead.

This makes the test suite incompatible with Ember 1.10, which seems reasonable given that we've now released 1.13, so the list of supported releases remains the same length.