### PR TITLE
Ember.keys is deprecated in favor of Object.keys

### DIFF
--- a/lib/ember-test-helpers/test-module.js
+++ b/lib/ember-test-helpers/test-module.js
@@ -192,7 +192,7 @@ export default Klass.extend({
     this.cache = this.cache || {};
     this.cachedCalls = this.cachedCalls || {};
 
-    var keys = Object.keys(callbacks);
+    var keys = (Object.keys || Ember.keys)(callbacks);
 
     for (var i = 0, l = keys.length; i < l; i++) {
       (function(key) {

--- a/lib/ember-test-helpers/test-module.js
+++ b/lib/ember-test-helpers/test-module.js
@@ -192,7 +192,7 @@ export default Klass.extend({
     this.cache = this.cache || {};
     this.cachedCalls = this.cachedCalls || {};
 
-    var keys = Ember.keys(callbacks);
+    var keys = Object.keys(callbacks);
 
     for (var i = 0, l = keys.length; i < l; i++) {
       (function(key) {


### PR DESCRIPTION
https://github.com/emberjs/ember.js/pull/11459 marks `Ember.keys` for deprecation in favor of Object.keys.