### PR TITLE
Call setupRouter()

### DIFF
--- a/lib/ember-test-helpers/test-module.js
+++ b/lib/ember-test-helpers/test-module.js
@@ -223,6 +223,7 @@ export default Klass.extend({
     var router = resolver.resolve('router:main');
     router = router || Ember.Router.extend();
     thingToRegisterWith.register('router:main', router);
+    thingToRegisterWith.lookup('router:main').setupRouter();
   },
 
   _setupIsolatedContainer: function() {


### PR DESCRIPTION
The router instance is never set up, though it is expected to be inside of the Ember Router at runtime. Related to [emberjs/ember.js#11610](https://github.com/emberjs/ember.js/issues/11610).