### PR TITLE
Guard against exceptions in the setup steps.

### DIFF
--- a/lib/ember-test-helpers/test-module.js
+++ b/lib/ember-test-helpers/test-module.js
@@ -107,7 +107,8 @@ export default Klass.extend({
     function nextStep() {
       var step = steps.shift();
       if (step) {
-        return Ember.RSVP.resolve(step.call(context)).then(nextStep);
+        // guard against exceptions, for example missing components referenced from needs.
+        return new Ember.RSVP.Promise(function(ok) {ok(step.call(context));}).then(nextStep);
       } else {
         return Ember.RSVP.resolve();
       }

--- a/lib/ember-test-helpers/test-module.js
+++ b/lib/ember-test-helpers/test-module.js
@@ -108,7 +108,9 @@ export default Klass.extend({
       var step = steps.shift();
       if (step) {
         // guard against exceptions, for example missing components referenced from needs.
-        return new Ember.RSVP.Promise(function(ok) {ok(step.call(context));}).then(nextStep);
+        return new Ember.RSVP.Promise(function(ok) {
+          ok(step.call(context));
+        }).then(nextStep);
       } else {
         return Ember.RSVP.resolve();
       }

--- a/tests/test-module-for-component-test.js
+++ b/tests/test-module-for-component-test.js
@@ -238,3 +238,17 @@ module('moduleForComponent: can be invoked with the component name and descripti
 test('it allows missing callbacks', function() {
   ok(true, 'no errors are thrown');
 });
+
+moduleForComponent('x-bad', {
+    needs: ['mis:sing'],
+    beforeEach: function(assert) {
+      // won't be called because of setup error
+      var done = assert.async();
+      assert.ok(true);
+      done();
+    }
+});
+
+test('it happens', function() {
+  expect(0);
+});


### PR DESCRIPTION
When there are exceptions in the setup steps (for example needs component missing)
the implementation is not properly capturing those exceptions.
This fix uses the slighlty longer syntax for creating promises which
wraps the call in a function and allows RSVP to properly capture
the exception. When using the shorter RSVP.resolve() form the exception
happens outside (before) the RSVP invocation and cannot be captured.