### PR TITLE
Update test-module-for-model.js

### DIFF
--- a/lib/ember-test-helpers/test-module-for-model.js
+++ b/lib/ember-test-helpers/test-module-for-model.js
@@ -23,8 +23,8 @@ export default TestModule.extend({
 
     callbacks.store = function(){
       var container = this.container;
-
-      return container.lookup('store:main');
+      var store = container.lookup('service:store') || container.lookup('store:main');
+      return store;
     };
 
     if (callbacks.subject === defaultSubject) {
@@ -32,7 +32,8 @@ export default TestModule.extend({
         var container = this.container;
 
         return Ember.run(function() {
-          return container.lookup('store:main').createRecord(modelName, options);
+          var store = container.lookup('service:store') || container.lookup('store:main');
+          return store.createRecord(modelName, options);
         });
       };
     }


### PR DESCRIPTION
This is to avoid deprecation warning:
```
You tried to look up 'store:main', but this has been deprecated in favor of 'service:store'.
```