### PR TITLE
Throw when integration and needs declared

### DIFF
--- a/lib/ember-test-helpers/test-module.js
+++ b/lib/ember-test-helpers/test-module.js
@@ -18,6 +18,10 @@ export default Klass.extend({
     this.name = description || subjectName;
     this.callbacks = callbacks || {};
 
+    if (this.callbacks.integration && this.callbacks.needs) {
+      throw new Error("cannot declare 'inegration: true' and 'needs' in the same module");
+    }
+
     if (this.callbacks.integration) {
       this.isIntegration = callbacks.integration;
       delete callbacks.integration;

--- a/tests/test-module-test.js
+++ b/tests/test-module-test.js
@@ -159,3 +159,20 @@ test("needs is not needed (pun intended) when integration is true", function() {
   var otherComponent = this.container.lookup('component:not-the-subject');
   ok(otherComponent, 'another component can be resolved when integration is true');
 });
+
+test("throws an error when declaring integration: true and needs in the same module", function() {
+  expect(3);
+
+  var result = false;
+
+  try {
+    moduleFor('component:x-foo', {
+      integration: true,
+      needs: ['component:x-bar']
+    });
+  } catch(err) {
+    result = true;
+  }
+
+  ok(result, "should throw an Error when integration: true and needs are provided");
+});


### PR DESCRIPTION
`needs` will switch off integration testing, this is not obvious. If
both are declared we should throw a descriptive Error.