### PR TITLE
Only override container methods if present.

### DIFF
--- a/lib/ember-test-helpers/build-registry.js
+++ b/lib/ember-test-helpers/build-registry.js
@@ -14,9 +14,11 @@ function exposeRegistryMethodsWithoutDeprecations(container) {
   ];
 
   function exposeRegistryMethod(container, method) {
-    container[method] = function() {
-      return container._registry[method].apply(container._registry, arguments);
-    };
+    if (method in container) {
+      container[method] = function() {
+        return container._registry[method].apply(container._registry, arguments);
+      };
+    }
   }
 
   for (var i = 0, l = methods.length; i < l; i++) {


### PR DESCRIPTION
The intent of this code initially was to suppress deprecation messages that could not be fixed by the test suite.

In Ember 2.0.0 these deprecated methods are being removed, this change ensures that we only expose them when the container already has them.

See https://github.com/emberjs/ember.js/pull/11853 for details.