### PR TITLE
Remove dependencies that are actually dev dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -25,12 +25,12 @@
   ],
   "dependencies": {
     "klassy": "cerebris/klassy.js#0.1.0",
-    "ember": "^1.13.0",
-    "ember-data": "canary",
-    "pretender": "^0.7.0"
+    "ember": "^1.13.0"
   },
   "devDependencies": {
     "qunit": "^1.15.0",
+    "ember-data": "canary",
+    "pretender": "^0.7.0",
     "loader.js": "ember-cli/loader.js#3.0.0",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "rwjblue/ember-cli-test-loader#0.0.4",

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -3,7 +3,9 @@ module.exports = {
     {
       name: 'ember-1.11.3',
       dependencies: {
-        "ember": "1.11.3",
+        "ember": "1.11.3"
+      },
+      devDependencies: {
         "ember-data": "~1.0.0-beta.19.2"
       }
     },
@@ -11,6 +13,8 @@ module.exports = {
       name: 'ember-1.12.1',
       dependencies: {
         "ember": "1.12.1",
+      },
+      devDependencies: {
         "ember-data": "~1.0.0-beta.19.2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "broccoli-static-compiler": "^0.1.4",
     "ember-cli": "^0.2.7",
     "ember-cli-release": "^0.2.4",
-    "ember-try": "0.0.7",
+    "ember-try": "0.0.8",
     "testem": "^0.6.19"
   }
 }


### PR DESCRIPTION
Tried upgrading to patch memory leaks, our tooling freaked out because it attempted to pull stuff from outside the fire wall that is not needed for runtime.