### PR TITLE
Consistently use the new view registry

### DIFF
--- a/lib/ember-test-helpers/test-module-for-component.js
+++ b/lib/ember-test-helpers/test-module-for-component.js
@@ -59,7 +59,7 @@ export default TestModule.extend({
       thingToRegisterWith.injection(this.subjectName, 'layout', layoutName);
     }
 
-    context.dispatcher = Ember.EventDispatcher.create();
+    context.dispatcher = this.container.lookup('event_dispatcher:main') || Ember.EventDispatcher.create();
     context.dispatcher.setup({}, '#ember-testing');
 
     this.callbacks.render = function() {
@@ -96,9 +96,16 @@ export default TestModule.extend({
 
     this.actionHooks = {};
 
-    context.dispatcher = Ember.EventDispatcher.create();
+    context.dispatcher = this.container.lookup('event_dispatcher:main') || Ember.EventDispatcher.create();
     context.dispatcher.setup({}, '#ember-testing');
     context.actions = module.actionHooks;
+
+    // This thing is registered as "view:" instead of "component:"
+    // because only views get the necessary _viewRegistry
+    // injection. Which is arguably an Ember bug, but doesn't impact
+    // normal app usage since apps always use a "view:" at the top
+    // level.
+    (this.registry || this.container).register('view:test-holder', Ember.Component.extend());
 
     context.render = function(template) {
       if (!template) {
@@ -110,9 +117,8 @@ export default TestModule.extend({
       if (typeof template === 'string') {
         template = Ember.Handlebars.compile(template);
       }
-      module.component = Ember.Component.create({
-        layout: template,
-        container: module.container
+      module.component = module.container.lookupFactory('view:test-holder').create({
+        layout: template
       });
 
       module.component.set('context' ,context);

--- a/lib/ember-test-helpers/test-module.js
+++ b/lib/ember-test-helpers/test-module.js
@@ -172,7 +172,7 @@ export default Klass.extend({
     this.context = undefined;
     unsetContext();
 
-    if (context.dispatcher) {
+    if (context.dispatcher && !context.dispatcher.isDestroyed) {
       Ember.run(function() {
         context.dispatcher.destroy();
       });
@@ -229,6 +229,7 @@ export default Klass.extend({
 
     this.container = items.container;
     this.registry = items.registry;
+
 
     var thingToRegisterWith = this.registry || this.container;
     var router = resolver.resolve('router:main');


### PR DESCRIPTION
Internally, the `EventDispatcher` looks for the global view registry on the container and then falls back to using `View.views`. Since we were creating it directly instead of via the container, it had no container reference, and so it was doing all view tracking using the fallback. 

This is problematic, because the global fallback path is now only accessible from inside Ember (by design, because we're trying to eliminate it.)