### PR TITLE
Allow overriding services/factories in the registry.

### DIFF
--- a/lib/ember-test-helpers/build-registry.js
+++ b/lib/ember-test-helpers/build-registry.js
@@ -27,7 +27,7 @@ function exposeRegistryMethodsWithoutDeprecations(container) {
 }
 
 export default function(resolver) {
-  var registry, container;
+  var fallbackRegistry, registry, container;
   var namespace = Ember.Object.create({
     Resolver: { create: function() { return resolver; } }
   });
@@ -41,10 +41,12 @@ export default function(resolver) {
   }
 
   if (Ember.Application.buildRegistry) {
-    registry = Ember.Application.buildRegistry(namespace);
-    registry.register('component-lookup:main', Ember.ComponentLookup);
+    fallbackRegistry = Ember.Application.buildRegistry(namespace);
+    fallbackRegistry.register('component-lookup:main', Ember.ComponentLookup);
 
-    registry = registry;
+    registry = new Ember.Registry({
+      fallback: fallbackRegistry
+    });
     container = registry.container();
     exposeRegistryMethodsWithoutDeprecations(container);
   } else {

--- a/lib/ember-test-helpers/test-module.js
+++ b/lib/ember-test-helpers/test-module.js
@@ -234,7 +234,6 @@ export default Klass.extend({
     this.container = items.container;
     this.registry = items.registry;
 
-
     var thingToRegisterWith = this.registry || this.container;
     var router = resolver.resolve('router:main');
     router = router || Ember.Router.extend();
@@ -253,7 +252,11 @@ export default Klass.extend({
       thingToRegisterWith.register(fullName, resolver.resolve(normalizedFullName));
     }
 
-    thingToRegisterWith.resolver = function() { };
+    if (this.registry) {
+      this.registry.fallback.resolver = function() {};
+    } else {
+      this.container.resolver = function() {};
+    }
   },
 
   _setupIntegratedContainer: function() {

--- a/tests/test-module-test.js
+++ b/tests/test-module-test.js
@@ -11,7 +11,10 @@ function moduleFor(fullName, description, callbacks) {
 function setupRegistry() {
   setResolverRegistry({
     'component:x-foo':           Ember.Component.extend(),
-    'component:not-the-subject': Ember.Component.extend()
+    'component:not-the-subject': Ember.Component.extend(),
+    'foo:thing': Ember.Object.extend({
+      fromDefaultRegistry: true
+    })
   });
 }
 
@@ -175,4 +178,28 @@ test("throws an error when declaring integration: true and needs in the same mod
   }
 
   ok(result, "should throw an Error when integration: true and needs are provided");
+});
+
+moduleFor('component:x-foo', 'should be able to override factories in integration mode', {
+  beforeSetup: function() {
+    setupRegistry();
+  },
+
+  integration: true
+});
+
+test('gets the default by default', function() {
+  var thing = this.container.lookup('foo:thing');
+
+  ok(thing.fromDefaultRegistry, 'found from the default registry');
+});
+
+test('can override the default', function() {
+  this.registry.register('foo:thing', Ember.Object.extend({
+    notTheDefault: true
+  }));
+  var thing = this.container.lookup('foo:thing');
+
+  ok(!thing.fromDefaultRegistry, 'should not be found from the default registry');
+  ok(thing.notTheDefault, 'found from the overridden factory');
 });


### PR DESCRIPTION
By default in Ember things that are automatically resolved take precedence over things that are manually registered. This is somewhat counterintuitive to many people, as they would like to be able to override a service or other factory in a given set of tests (for example to use a mock analytics service).

The ability to do this has existed since the SSR/Fastboot work that split the registry from the container in 1.11, but I only recently realized how I could leverage that work here.

This change adds new functionality on Ember 1.11+, but allows older versions to continue to work as they do today (aka non-breaking).

---

Example:

Assuming you have a `app/services/analytics.js` and want to use a mock service for a set of component integration tests, you might do something like this:

```javascript
import MockAnalyticsService from '../mock-services/analytics';
import { moduleForComponent, test } from 'ember-qunit';

moduleForComponent('something-cool', {
  integration: true,
  beforeEach() {
    this.registry.register('service:analytics', MockAnalyticsService);
  }
});
```

In the above scenario, the mock service would be used instead of the one at `app/services/analytics.js`.