### PR TITLE
Fix typo in thrown error

### DIFF
--- a/lib/ember-test-helpers/test-module.js
+++ b/lib/ember-test-helpers/test-module.js
@@ -19,7 +19,7 @@ export default Klass.extend({
     this.callbacks = callbacks || {};
 
     if (this.callbacks.integration && this.callbacks.needs) {
-      throw new Error("cannot declare 'inegration: true' and 'needs' in the same module");
+      throw new Error("cannot declare 'integration: true' and 'needs' in the same module");
     }
 
     if (this.callbacks.integration) {


### PR DESCRIPTION
Fixes a typo in the error message when declaring both `integration: true` and `needs` in the same module