### PR TITLE
Do not register a router service for Ember <1.13

### DIFF
--- a/lib/ember-test-helpers/has-ember-version.js
+++ b/lib/ember-test-helpers/has-ember-version.js
@@ -1,0 +1,8 @@
+import Ember from 'ember';
+
+export default function hasEmberVersion(major, minor) {
+  var numbers = Ember.VERSION.split('-')[0].split('.');
+  var actualMajor = parseInt(numbers[0], 10);
+  var actualMinor = parseInt(numbers[1], 10);
+  return actualMajor > major || (actualMajor === major && actualMinor >= minor);
+}

--- a/lib/ember-test-helpers/test-module.js
+++ b/lib/ember-test-helpers/test-module.js
@@ -3,6 +3,7 @@ import { getContext, setContext, unsetContext } from './test-context';
 import { Klass } from 'klassy';
 import { getResolver } from './test-resolver';
 import buildRegistry from './build-registry';
+import hasEmberVersion from './has-ember-version';
 
 export default Klass.extend({
   init: function(subjectName, description, callbacks) {
@@ -234,10 +235,12 @@ export default Klass.extend({
     this.container = items.container;
     this.registry = items.registry;
 
-    var thingToRegisterWith = this.registry || this.container;
-    var router = resolver.resolve('router:main');
-    router = router || Ember.Router.extend();
-    thingToRegisterWith.register('router:main', router);
+    if (hasEmberVersion(1, 13)) {
+      var thingToRegisterWith = this.registry || this.container;
+      var router = resolver.resolve('router:main');
+      router = router || Ember.Router.extend();
+      thingToRegisterWith.register('router:main', router);
+    }
   },
 
   _setupIsolatedContainer: function() {

--- a/tests/test-module-for-component-test.js
+++ b/tests/test-module-for-component-test.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import { TestModuleForComponent } from 'ember-test-helpers';
+import hasEmberVersion from 'ember-test-helpers/has-ember-version';
 import test from 'tests/test-support/qunit-test';
 import qunitModuleFor from 'tests/test-support/qunit-module-for';
 import { setResolverRegistry } from 'tests/test-support/resolver';
@@ -237,7 +238,7 @@ moduleForComponent('changing-color', 'component:changing-color -- handles closur
   integration: true
 });
 
-if (!/^1\.(11|12)/.test(Ember.VERSION)) {
+if (hasEmberVersion(1,13)) {
   test('handles a closure actions', function() {
     expect(1);
     this.on('colorChange', function(arg) { equal(arg, 'foo'); });

--- a/tests/test-module-for-integration-test.js
+++ b/tests/test-module-for-integration-test.js
@@ -26,6 +26,11 @@ test('it can render a template', function() {
   equal(this.$('span').text(), 'Hello');
 });
 
+test('it can render a link-to', function() {
+  this.render("{{link-to 'Hi' 'index'}}");
+  ok(true, 'it renders without fail');
+});
+
 test('it complains if you try to use bare render', function() {
   var self = this;
   throws(function() {


### PR DESCRIPTION
Versions of Ember prior to 1.13 require a full router booted by the app, or no router at all. This ensures they receive no router at all instead of the 1.13-safe one. Result is that the link-to helper can be used in Ember 1.11 and 1.12 component tests (unit and integration).

See also these PRs that attempted to fix the issue in Ember:

* https://github.com/emberjs/ember.js/pull/11829
* https://github.com/emberjs/ember.js/issues/11825

IMO, it is more appropriate that it be fixed here, since ember-test-helpers is basically dealing with fragile/intimate API surface when it sets up a router in the container.