### PR TITLE
Move action handling from module to context

### DIFF
--- a/lib/ember-test-helpers/test-module-for-component.js
+++ b/lib/ember-test-helpers/test-module-for-component.js
@@ -135,7 +135,7 @@ export default TestModule.extend({
       });
 
       module.component.set('context' ,context);
-      module.component.set('controller', module);
+      module.component.set('controller', context);
 
       Ember.run(function() {
         module.component.appendTo('#ember-testing');
@@ -170,7 +170,13 @@ export default TestModule.extend({
     context.on = function(actionName, handler) {
       module.actionHooks[actionName] = handler;
     };
-
+    context.send = function(actionName) {
+      var hook = module.actionHooks[actionName];
+      if (!hook) {
+        throw new Error("integration testing template received unexpected action " + actionName);
+      }
+      hook.apply(module, Array.prototype.slice.call(arguments, 1));
+    };
   },
 
   setupContext: function() {
@@ -185,14 +191,6 @@ export default TestModule.extend({
     if (!this.isUnitTest) {
       this.context.factory = function() {};
     }
-  },
-
-  send: function(actionName) {
-    var hook = this.actionHooks[actionName];
-    if (!hook) {
-      throw new Error("integration testing template received unexpected action " + actionName);
-    }
-    hook.apply(this, Array.prototype.slice.call(arguments, 1));
   },
 
   teardownComponent: function() {


### PR DESCRIPTION
This fixes canary, where "controller" no longer works to redirect actions. Fixes #99.