### PR TITLE
Add `id` and `until` to deprecations.

### DIFF
--- a/lib/ember-test-helpers/test-module-for-component.js
+++ b/lib/ember-test-helpers/test-module-for-component.js
@@ -19,7 +19,14 @@ export default TestModule.extend({
     } else if (callbacks.integration) {
       this.isUnitTest = false;
     } else {
-      Ember.deprecate("the component:" + componentName + " test module is implicitly running in unit test mode, which will change to integration test mode by default in an upcoming version of ember-test-helpers. Add `unit: true` or a `needs:[]` list to explicitly opt in to unit test mode.");
+      Ember.deprecate(
+        "the component:" + componentName + " test module is implicitly running in unit test mode, " +
+        "which will change to integration test mode by default in an upcoming version of " +
+        "ember-test-helpers. Add `unit: true` or a `needs:[]` list to explicitly opt in to unit " +
+        "test mode.",
+        false,
+        { id: 'ember-test-helpers.test-module-for-component.test-type', until: '0.6.0' }
+      );
       this.isUnitTest = true;
     }
 
@@ -96,7 +103,11 @@ export default TestModule.extend({
     };
 
     this.callbacks.append = function() {
-      Ember.deprecate('this.append() is deprecated. Please use this.render() or this.$() instead.');
+      Ember.deprecate(
+        'this.append() is deprecated. Please use this.render() or this.$() instead.',
+        false,
+        { id: 'ember-test-helpers.test-module-for-component.append', until: '0.6.0' }
+      );
       return context.$();
     };
 


### PR DESCRIPTION
As of Ember 2.1.0, calling `Ember.deprecate` without an options hash including `id` and `until` will actually trigger another deprecation.

This adds the required properties to `Ember.deprecate`'s options hash.