### PR TITLE
prepend tear down steps like tearDownForComponent in the begining of tearDownSteps array

### DIFF
--- a/lib/ember-test-helpers/test-module-for-component.js
+++ b/lib/ember-test-helpers/test-module-for-component.js
@@ -47,12 +47,12 @@ export default TestModule.extend({
         throw new Error("component integration tests do not support `subject()`.");
       };
       this.setupSteps.push(this.setupComponentIntegrationTest);
-      this.teardownSteps.push(this.teardownComponent);
+      this.teardownSteps.unshift(this.teardownComponent);
     }
 
     if (Ember.View && Ember.View.views) {
       this.setupSteps.push(this._aliasViewRegistry);
-      this.teardownSteps.push(this._resetViewRegistry);
+      this.teardownSteps.unshift(this._resetViewRegistry);
     }
   },
 

--- a/tests/test-module-for-integration-test.js
+++ b/tests/test-module-for-integration-test.js
@@ -252,3 +252,26 @@ test('can inject a service directly into test context, with aliased name', funct
   this.set('hornedBeast.sparkliness', 'amazing');
   equal(this.$('.x-foo').text().trim(), "amazing");
 });
+
+moduleForComponent('Component Integration Tests: willDestoryElement', {
+  integration: true,
+  beforeSetup: function() {
+    setResolverRegistry({
+      'component:my-component': Ember.Component.extend({
+        willDestroyElement: function() {
+          var stateIndicatesInDOM = (this._state === 'inDOM');
+          var actuallyInDOM = Ember.$.contains(document, this.$()[0]);
+
+          ok((actuallyInDOM === true) && (actuallyInDOM === stateIndicatesInDOM), 'component should still be in the DOM');
+      }
+
+      })
+    });
+  }
+});
+
+test('still in DOM in willDestroyElement', function() {
+    expect(1);
+    this.render("{{my-component}}");
+
+});


### PR DESCRIPTION
Currently,   [component.destroy()](https://github.com/switchfly/ember-test-helpers/blob/master/lib/ember-test-helpers/test-module-for-component.js#L211)  is only run after  #ember-testing DOM element is [emptied](https://github.com/switchfly/ember-test-helpers/blob/master/lib/ember-test-helpers/test-module.js#L188). When the component which use third party library  like jquery-ui  or bootstrap javascript component do cleanup using  willDestroyElement() hook, it cannot cleanup properly  because the element is already removed from DOM. In additional , teardownStep should be run in reverse order as setupSteps in general. So this PR also fix the [_resetViewRegistry()](https://github.com/switchfly/ember-test-helpers/blob/master/lib/ember-test-helpers/test-module-for-component.js#L55) hook in TestModuleForComponent.

