### PR TITLE
Add public API for injection & registration

### DIFF
--- a/lib/ember-test-helpers/test-module.js
+++ b/lib/ember-test-helpers/test-module.js
@@ -143,10 +143,22 @@ export default Klass.extend({
       container:  this.container,
       registry: this.registry,
       factory:    factory,
-      dispatcher: null
+      dispatcher: null,
+      register: function() {
+        var target = this.registry || this.container;
+        return target.register.apply(target, arguments);
+      },
+      inject: {}
     });
 
-    this.context = getContext();
+    var context = this.context = getContext();
+
+    Object.keys(Ember.inject).forEach(function(typeName) {
+      context.inject[typeName] = function(name, opts) {
+        var alias = (opts && opts.as) || name;
+        Ember.set(context, alias, context.container.lookup(typeName + ':' + name));
+      };
+    });
   },
 
   setupTestElements: function() {

--- a/tests/test-module-for-integration-test.js
+++ b/tests/test-module-for-integration-test.js
@@ -191,6 +191,61 @@ moduleForComponent('Component Integration Tests: implicit views are not deprecat
 
 test('the toplevel view is not deprecated', function () {
   expect(0);
-  (this.registry || this.container).register('component:my-toplevel', this.container.lookupFactory('view:toplevel'));
+  this.register('component:my-toplevel', this.container.lookupFactory('view:toplevel'));
   this.render("{{my-toplevel}}");
+});
+
+
+moduleForComponent('Component Integration Tests: register and inject', {
+  integration: true
+});
+
+test('can register a component', function() {
+  this.register('component:x-foo', Ember.Component.extend({
+    classNames: ['i-am-x-foo']
+  }));
+  this.render("{{x-foo}}");
+  equal(this.$('.i-am-x-foo').length, 1, "found i-am-x-foo");
+});
+
+test('can register a service', function() {
+  this.register('component:x-foo', Ember.Component.extend({
+    unicorn: Ember.inject.service(),
+    layout: Ember.Handlebars.compile('<span class="x-foo">{{unicorn.sparkliness}}</span>')
+  }));
+  this.register('service:unicorn', Ember.Component.extend({
+    sparkliness: 'extreme'
+  }));
+  this.render("{{x-foo}}");
+  equal(this.$('.x-foo').text().trim(), "extreme");
+});
+
+test('can inject a service directly into test context', function() {
+  this.register('component:x-foo', Ember.Component.extend({
+    unicorn: Ember.inject.service(),
+    layout: Ember.Handlebars.compile('<span class="x-foo">{{unicorn.sparkliness}}</span>')
+  }));
+  this.register('service:unicorn', Ember.Component.extend({
+    sparkliness: 'extreme'
+  }));
+  this.inject.service('unicorn');
+  this.render("{{x-foo}}");
+  equal(this.$('.x-foo').text().trim(), "extreme");
+  this.set('unicorn.sparkliness', 'amazing');
+  equal(this.$('.x-foo').text().trim(), "amazing");
+});
+
+test('can inject a service directly into test context, with aliased name', function() {
+  this.register('component:x-foo', Ember.Component.extend({
+    unicorn: Ember.inject.service(),
+    layout: Ember.Handlebars.compile('<span class="x-foo">{{unicorn.sparkliness}}</span>')
+  }));
+  this.register('service:unicorn', Ember.Component.extend({
+    sparkliness: 'extreme'
+  }));
+  this.inject.service('unicorn', { as: 'hornedBeast' });
+  this.render("{{x-foo}}");
+  equal(this.$('.x-foo').text().trim(), "extreme");
+  this.set('hornedBeast.sparkliness', 'amazing');
+  equal(this.$('.x-foo').text().trim(), "amazing");
 });

--- a/tests/test-module-test.js
+++ b/tests/test-module-test.js
@@ -73,8 +73,7 @@ moduleFor('component:x-foo', 'component:x-foo -- setup context', {
       name: 'Max'
     });
 
-    var thingToRegisterWith = this.registry || this.container;
-    thingToRegisterWith.register('service:blah', Ember.Object.extend({
+    this.register('service:blah', Ember.Object.extend({
       purpose: 'blabering'
     }));
   }
@@ -85,9 +84,8 @@ test("subject can be initialized in setup", function() {
 });
 
 test("can lookup factory registered in setup", function() {
-  var service = this.container.lookup('service:blah');
-
-  equal(service.get('purpose'), 'blabering');
+  this.inject.service('blah');
+  equal(Ember.get(this, 'blah.purpose'), 'blabering');
 });
 
 moduleFor('component:x-foo', 'component:x-foo -- callback context', {
@@ -195,7 +193,7 @@ test('gets the default by default', function() {
 });
 
 test('can override the default', function() {
-  this.registry.register('foo:thing', Ember.Object.extend({
+  this.register('foo:thing', Ember.Object.extend({
     notTheDefault: true
   }));
   var thing = this.container.lookup('foo:thing');


### PR DESCRIPTION
In an app, we encourages users to use injection over container.lookup,
and we encourage `application.register` over `registry.register`. But in our integration tests, there is no good alternative to direct `this.container.lookup` and `this.registry.register`.

So I added `register` and `inject` capability directly to the integration test context. `register` is fairly trivial:

```js
    test('registering something', function(assert) {
      this.register('component:x-foo', Ember.Component.extend({
        classNames: ['i-am-x-foo']
      }));
      this.render(hbs`{{x-foo}}`);
      assert.equal(this.$('.i-am-x-foo').length, 1, 'found x-foo');
    });
```

`inject` lets you inject anything into the test context:

```js
    test('injecting a service', function(assert) {
      this.inject.service('notifications');
      this.render(hbs`{{my-notification-viewer}}`);

      // The notifications service has been injected into our test context,
      // so we can access it here and tell it to do something.
      this.get('notifications').receivedNotification("Hello world");

      assert.equal(this.$('.notification').text(), 'Hello world');
    })
```

You can also give the injected thing an alternate name using `as`:

```js
    test('injecting a service with aliased name', function(assert) {
      this.inject.service('notifications', { as: 'messages' });
      this.render(hbs`{{my-notification-viewer}}`);

      // The notifications service has been injected into our test context
      // as this.get('messages').
      this.get('messages').receivedNotification("Hello world");

      assert.equal(this.$('.notification').text(), 'Hello world');
    })
```