### PR TITLE
Guard for missing Ember.inject.

### DIFF
--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,33 +1,42 @@
 module.exports = {
   scenarios: [
     {
-      name: 'ember-1.11.3',
+      name: 'ember-1.10',
       dependencies: {
-        "ember": "1.11.3"
+        "ember": "~1.10.0"
       },
       devDependencies: {
         "ember-data": "~1.0.0-beta.19.2"
       }
     },
     {
-      name: 'ember-1.12.1',
+      name: 'ember-1.11',
       dependencies: {
-        "ember": "1.12.1",
+        "ember": "~1.11.3"
       },
       devDependencies: {
         "ember-data": "~1.0.0-beta.19.2"
       }
     },
     {
-      name: 'ember-1.13.8',
+      name: 'ember-1.12',
       dependencies: {
-        "ember": "1.13.8"
+        "ember": "~1.12.1"
+      },
+      devDependencies: {
+        "ember-data": "~1.0.0-beta.19.2"
       }
     },
     {
-      name: 'ember-2.0.0',
+      name: 'ember-1.13',
       dependencies: {
-        "ember": "2.0.0"
+        "ember": "~1.13.8"
+      }
+    },
+    {
+      name: 'ember-2.0',
+      dependencies: {
+        "ember": "~2.0.0"
       },
       devDependencies: {
         "ember-data": "~2.0.0-beta.2"
@@ -39,7 +48,7 @@ module.exports = {
         "ember": "components/ember#release"
       },
       devDependencies: {
-        "ember-data": "~2.0.0-beta.2"
+        "ember-data": "~2.0.0"
       },
       resolutions: {
         "ember": "release"
@@ -51,7 +60,7 @@ module.exports = {
         "ember": "components/ember#beta"
       },
       devDependencies: {
-        "ember-data": "~2.0.0-beta.2"
+        "ember-data": "~2.0.0"
       },
       resolutions: {
         "ember": "beta"
@@ -63,7 +72,7 @@ module.exports = {
         "ember": "components/ember#canary"
       },
       devDependencies: {
-        "ember-data": "~2.0.0-beta.2"
+        "ember-data": "~2.0.0"
       },
       resolutions: {
         "ember": "canary"

--- a/lib/ember-test-helpers/test-module.js
+++ b/lib/ember-test-helpers/test-module.js
@@ -153,12 +153,15 @@ export default Klass.extend({
 
     var context = this.context = getContext();
 
-    Object.keys(Ember.inject).forEach(function(typeName) {
-      context.inject[typeName] = function(name, opts) {
-        var alias = (opts && opts.as) || name;
-        Ember.set(context, alias, context.container.lookup(typeName + ':' + name));
-      };
-    });
+    if (Ember.inject) {
+      var keys = (Object.keys || Ember.keys)(Ember.inject);
+      keys.forEach(function(typeName) {
+        context.inject[typeName] = function(name, opts) {
+          var alias = (opts && opts.as) || name;
+          Ember.set(context, alias, context.container.lookup(typeName + ':' + name));
+        };
+      });
+    }
   },
 
   setupTestElements: function() {

--- a/tests/test-module-for-component-test.js
+++ b/tests/test-module-for-component-test.js
@@ -126,15 +126,17 @@ test('can lookup components in its layout', function() {
   equal(component._state, 'inDOM');
 });
 
-test('can use the component keyword in its layout', function() {
-  expect(1);
-  var component = this.subject({
-    colors: ['red', 'green', 'blue'],
-    layout: Ember.Handlebars.compile("{{component 'x-foo'}}")
+if (hasEmberVersion(1,11)) {
+  test('can use the component keyword in its layout', function() {
+    expect(1);
+    var component = this.subject({
+      colors: ['red', 'green', 'blue'],
+      layout: Ember.Handlebars.compile("{{component 'x-foo'}}")
+    });
+    this.render();
+    equal(component._state, 'inDOM');
   });
-  this.render();
-  equal(component._state, 'inDOM');
-});
+}
 
 test('clears out views from test to test', function() {
   expect(1);

--- a/tests/test-module-for-integration-test.js
+++ b/tests/test-module-for-integration-test.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import hasEmberVersion from 'ember-test-helpers/has-ember-version';
 import { TestModuleForComponent } from 'ember-test-helpers';
 import test from 'tests/test-support/qunit-test';
 import qunitModuleFor from 'tests/test-support/qunit-module-for';
@@ -26,10 +27,12 @@ test('it can render a template', function() {
   equal(this.$('span').text(), 'Hello');
 });
 
-test('it can render a link-to', function() {
-  this.render("{{link-to 'Hi' 'index'}}");
-  ok(true, 'it renders without fail');
-});
+if (hasEmberVersion(1,11)) {
+  test('it can render a link-to', function() {
+    this.render("{{link-to 'Hi' 'index'}}");
+    ok(true, 'it renders without fail');
+  });
+}
 
 test('it complains if you try to use bare render', function() {
   var self = this;

--- a/tests/test-module-test.js
+++ b/tests/test-module-test.js
@@ -1,4 +1,5 @@
 import { TestModule, getContext } from 'ember-test-helpers';
+import hasEmberVersion from 'ember-test-helpers/has-ember-version';
 import test from 'tests/test-support/qunit-test';
 import qunitModuleFor from 'tests/test-support/qunit-module-for';
 import { setResolverRegistry } from 'tests/test-support/resolver';
@@ -178,26 +179,28 @@ test("throws an error when declaring integration: true and needs in the same mod
   ok(result, "should throw an Error when integration: true and needs are provided");
 });
 
-moduleFor('component:x-foo', 'should be able to override factories in integration mode', {
-  beforeSetup: function() {
-    setupRegistry();
-  },
+if (hasEmberVersion(1,11)) {
+  moduleFor('component:x-foo', 'should be able to override factories in integration mode', {
+    beforeSetup: function() {
+      setupRegistry();
+    },
 
-  integration: true
-});
+    integration: true
+  });
 
-test('gets the default by default', function() {
-  var thing = this.container.lookup('foo:thing');
+  test('gets the default by default', function() {
+    var thing = this.container.lookup('foo:thing');
 
-  ok(thing.fromDefaultRegistry, 'found from the default registry');
-});
+    ok(thing.fromDefaultRegistry, 'found from the default registry');
+  });
 
-test('can override the default', function() {
-  this.register('foo:thing', Ember.Object.extend({
-    notTheDefault: true
-  }));
-  var thing = this.container.lookup('foo:thing');
+  test('can override the default', function() {
+    this.register('foo:thing', Ember.Object.extend({
+      notTheDefault: true
+    }));
+    var thing = this.container.lookup('foo:thing');
 
-  ok(!thing.fromDefaultRegistry, 'should not be found from the default registry');
-  ok(thing.notTheDefault, 'found from the overridden factory');
-});
+    ok(!thing.fromDefaultRegistry, 'should not be found from the default registry');
+    ok(thing.notTheDefault, 'found from the overridden factory');
+  });
+}


### PR DESCRIPTION
This is not present on Ember < 1.10.

Also, update ember-try config for Ember 1.10 support.