### PR TITLE
Add `wait` helper.

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -25,7 +25,7 @@ var lib = pickFiles('lib', {
 
 var tests = pickFiles('tests', {
   srcDir: '/',
-  files: ['test-support/*.js', '*.js'],
+  files: ['**/*.js'],
   destDir: '/tests'
 });
 

--- a/bower.json
+++ b/bower.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "qunit": "^1.15.0",
     "ember-data": "1.13.9",
-    "pretender": "^0.7.0",
+    "pretender": "~0.10.1",
     "loader.js": "ember-cli/loader.js#3.0.0",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "rwjblue/ember-cli-test-loader#0.0.4",

--- a/lib/ember-test-helpers/test-module.js
+++ b/lib/ember-test-helpers/test-module.js
@@ -4,6 +4,7 @@ import { Klass } from 'klassy';
 import { getResolver } from './test-resolver';
 import buildRegistry from './build-registry';
 import hasEmberVersion from './has-ember-version';
+import { _setupAJAXHooks, _teardownAJAXHooks } from './wait';
 
 export default Klass.extend({
   init: function(subjectName, description, callbacks) {
@@ -58,6 +59,7 @@ export default Klass.extend({
     this.setupSteps.push(this.setupContainer);
     this.setupSteps.push(this.setupContext);
     this.setupSteps.push(this.setupTestElements);
+    this.setupSteps.push(this.setupAJAXListeners);
 
     if (this.callbacks.setup) {
       this.contextualizedSetupSteps.push( this.callbacks.setup );
@@ -78,6 +80,7 @@ export default Klass.extend({
     this.teardownSteps.push(this.teardownContainer);
     this.teardownSteps.push(this.teardownContext);
     this.teardownSteps.push(this.teardownTestElements);
+    this.teardownSteps.push(this.teardownAJAXListeners);
 
     if (this.callbacks.afterTeardown) {
       this.teardownSteps.push( this.callbacks.afterTeardown );
@@ -170,6 +173,10 @@ export default Klass.extend({
     }
   },
 
+  setupAJAXListeners: function() {
+    _setupAJAXHooks();
+  },
+
   teardownSubject: function() {
     var subject = this.cache.subject;
 
@@ -207,6 +214,10 @@ export default Klass.extend({
     if (Ember.View && Ember.View.views) {
       Ember.View.views = {};
     }
+  },
+
+  teardownAJAXListeners: function() {
+    _teardownAJAXHooks();
   },
 
   defaultSubject: function(options, factory) {

--- a/lib/ember-test-helpers/wait.js
+++ b/lib/ember-test-helpers/wait.js
@@ -1,0 +1,18 @@
+import Ember from 'ember';
+
+export default function wait() {
+  return new Ember.RSVP.Promise(function(resolve) {
+    var watcher = self.setInterval(function() {
+      // If there are scheduled timers or we are inside of a run loop, keep polling
+      if (Ember.run.hasScheduledTimers() || Ember.run.currentRunLoop) {
+        return;
+      }
+
+      // Stop polling
+      self.clearInterval(watcher);
+
+      // Synchronously resolve the promise
+      Ember.run(null, resolve);
+    }, 10);
+  });
+}

--- a/lib/ember-test-helpers/wait.js
+++ b/lib/ember-test-helpers/wait.js
@@ -1,10 +1,42 @@
 import Ember from 'ember';
 
-export default function wait() {
+var requests;
+function incrementAjaxPendingRequests(_, xhr) {
+  requests.push(xhr);
+}
+
+function decrementAjaxPendingRequests(_, xhr) {
+  for (var i = 0;i < requests.length;i++) {
+    if (xhr === requests[i]) {
+      requests.splice(i, 1);
+    }
+  }
+}
+
+export function _teardownAJAXHooks() {
+  jQuery(document).off('ajaxSend', incrementAjaxPendingRequests);
+  jQuery(document).off('ajaxComplete', decrementAjaxPendingRequests);
+}
+
+export function _setupAJAXHooks() {
+  requests = [];
+
+  jQuery(document).on('ajaxSend', incrementAjaxPendingRequests);
+  jQuery(document).on('ajaxComplete', decrementAjaxPendingRequests);
+}
+
+export default function wait(_options) {
+  var options = _options || {};
+  var waitForTimers = options.hasOwnProperty('waitForTimers') ? options.waitForTimers : true;
+  var waitForAJAX = options.hasOwnProperty('waitForAJAX') ? options.waitForAJAX : true;
+
   return new Ember.RSVP.Promise(function(resolve) {
     var watcher = self.setInterval(function() {
-      // If there are scheduled timers or we are inside of a run loop, keep polling
-      if (Ember.run.hasScheduledTimers() || Ember.run.currentRunLoop) {
+      if (waitForTimers && (Ember.run.hasScheduledTimers() || Ember.run.currentRunLoop)) {
+        return;
+      }
+
+      if (waitForAJAX && requests && requests.length > 0) {
         return;
       }
 

--- a/tests/wait-test.js
+++ b/tests/wait-test.js
@@ -1,0 +1,72 @@
+import Ember from 'ember';
+import { TestModuleForComponent } from 'ember-test-helpers';
+import test from 'tests/test-support/qunit-test';
+import qunitModuleFor from 'tests/test-support/qunit-module-for';
+import { setResolverRegistry } from 'tests/test-support/resolver';
+
+import wait from 'ember-test-helpers/wait';
+
+function moduleForComponent(name, description, callbacks) {
+  var module = new TestModuleForComponent(name, description, callbacks);
+  qunitModuleFor(module);
+}
+
+
+moduleForComponent('wait helper tests', {
+  integration: true,
+  setup: function() {
+    this.register('component:x-test-1', Ember.Component.extend({
+      internalValue: 'initial value',
+
+      init: function() {
+        this._super.apply(this, arguments);
+
+        Ember.run.later(this, function() {
+          this.set('internalValue', 'async value');
+        }, 10);
+      }
+    }));
+
+    this.register('template:components/x-test-1', Ember.Handlebars.compile("{{internalValue}}"));
+
+    this.register('component:x-test-2', Ember.Component.extend({
+      internalValue: 'initial value',
+
+      click: function() {
+        Ember.run.later(this, function() {
+          this.set('internalValue', 'async value');
+        }, 10);
+      }
+    }));
+
+    this.register('template:components/x-test-2', Ember.Handlebars.compile(
+      "{{internalValue}}"
+    ));
+  }
+});
+
+test('it works when async exists in `init`', function() {
+  var testContext = this;
+
+  this.render('{{x-test-1}}');
+
+  return wait()
+    .then(function() {
+      equal(testContext.$().text(), 'async value');
+    });
+});
+
+test('it works when async exists in an event/action', function() {
+  var testContext = this;
+
+  this.render('{{x-test-2}}');
+
+  equal(this.$().text(), 'initial value');
+
+  this.$('div').click();
+
+  return wait()
+    .then(function() {
+      equal(testContext.$().text(), 'async value');
+    });
+});


### PR DESCRIPTION
This allows component integration tests that need to deal with async interactions to have an easy way to model their tests.

Example test (assuming the component does some async in an action triggered by the button click):

```javascript
import { moduleForComponent, test } from 'ember-test-helpers';
import wait from 'ember-test-helpers/wait';

test('it works when async exists in an event/action', function(assert) {
  this.render('{{my-foo}}');

  this.$('button').click();

  return wait()
    .then(() => {
      // assertions for after async behavior
    });
});
```

The guts of this `wait` helper are pulled from the `wait` acceptance test helper in Ember itself. Eventually we may be able to make Ember itself provide an implementation that we can share here and in the acceptance testing world.