### PR TITLE
Fix issues with normalization in primary (non-fallback) registry.

### DIFF
--- a/lib/ember-test-helpers/build-registry.js
+++ b/lib/ember-test-helpers/build-registry.js
@@ -47,6 +47,15 @@ export default function(resolver) {
     registry = new Ember.Registry({
       fallback: fallbackRegistry
     });
+
+    // these properties are set on the fallback registry by `buildRegistry`
+    // and on the primary registry within the ApplicationInstance constructor
+    // but we need to manually recreate them since ApplicationInstance's are not
+    // exposed externally
+    registry.normalizeFullName = fallbackRegistry.normalizeFullName;
+    registry.makeToString = fallbackRegistry.makeToString;
+    registry.describe = fallbackRegistry.describe;
+
     container = registry.container();
     exposeRegistryMethodsWithoutDeprecations(container);
   } else {

--- a/tests/test-module-test.js
+++ b/tests/test-module-test.js
@@ -15,7 +15,11 @@ function setupRegistry() {
     'component:not-the-subject': Ember.Component.extend(),
     'foo:thing': Ember.Object.extend({
       fromDefaultRegistry: true
+    }),
+    'service:other-thing': Ember.Object.extend({
+      fromDefaultRegistry: true
     })
+
   });
 }
 
@@ -199,6 +203,33 @@ if (hasEmberVersion(1,11)) {
       notTheDefault: true
     }));
     var thing = this.container.lookup('foo:thing');
+
+    ok(!thing.fromDefaultRegistry, 'should not be found from the default registry');
+    ok(thing.notTheDefault, 'found from the overridden factory');
+  });
+
+  test('gets the default with fullName normalization by default', function() {
+    this.register('foo:needs-service', Ember.Object.extend({
+      otherThing: Ember.inject.service()
+    }));
+
+    var foo = this.container.lookup('foo:needs-service');
+    var thing = foo.get('otherThing');
+
+    ok(thing.fromDefaultRegistry, 'found from the default registry');
+  });
+
+  test('can override the default with fullName normalization', function() {
+    this.register('service:other-thing', Ember.Object.extend({
+      notTheDefault: true
+    }));
+
+    this.register('foo:needs-service', Ember.Object.extend({
+      otherThing: Ember.inject.service()
+    }));
+
+    var foo = this.container.lookup('foo:needs-service');
+    var thing = foo.get('otherThing');
 
     ok(!thing.fromDefaultRegistry, 'should not be found from the default registry');
     ok(thing.notTheDefault, 'found from the overridden factory');


### PR DESCRIPTION
When Ember internally builds a registry via `Ember.Application.buildRegistry` it aliases `registry.normalizeFullName` to `resolver.normalize` and this becomes the fallback registry.  Then Ember creates the primary registry (in `ApplicationInstance`'s constructor) and provides the primary registry's resolver (which is `function() { }` to allow for registration overrides) with the original (aka from the `fallback` registry) `normalizeFullName`.

Unfortunately, when this was initially implemented in ember-test-helpers I missed this nuance and we subsequently had many issues reported for things that the normalize method would have fixed (specifically converting `service:fooBar` to `service:foo-bar` before looking up).

It would be better IMO if `Ember.Registry` could be made aware of this resolver shenanigans, and provide a hook that can be called to "wrapFallbackRegistry" or somesuch so that ember-test-helpers (and `ApplicationInstance` in Ember) do not need to know about these "magic" methods.

Fixes #108.
Fixes https://github.com/rwjblue/ember-qunit/issues/200
Fixes https://github.com/rwjblue/ember-qunit/issues/199