### PR TITLE
Add support for `integration: 'legacy'`

### DIFF
--- a/lib/ember-test-helpers/test-module-for-component.js
+++ b/lib/ember-test-helpers/test-module-for-component.js
@@ -1,4 +1,4 @@
-import TestModule from './test-module';
+import { default as TestModule, UNIT_TEST, LEGACY_INTEGRATION_TEST, INTEGRATION_TEST } from './test-module';
 import Ember from 'ember';
 import { getResolver } from './test-resolver';
 
@@ -14,11 +14,7 @@ export default TestModule.extend({
 
     this.componentName = componentName;
 
-    if (callbacks.needs || callbacks.unit || callbacks.integration === false) {
-      this.isUnitTest = true;
-    } else if (callbacks.integration) {
-      this.isUnitTest = false;
-    } else {
+    if (! (callbacks.needs || callbacks.unit) && this.isUnitTest()) {
       Ember.deprecate(
         "the component:" + componentName + " test module is implicitly running in unit test mode, " +
         "which will change to integration test mode by default in an upcoming version of " +
@@ -27,11 +23,6 @@ export default TestModule.extend({
         false,
         { id: 'ember-test-helpers.test-module-for-component.test-type', until: '0.6.0' }
       );
-      this.isUnitTest = true;
-    }
-
-    if (!this.isUnitTest) {
-      callbacks.integration = true;
     }
 
     if (description) {
@@ -40,14 +31,23 @@ export default TestModule.extend({
       this._super.call(this, 'component:' + componentName, callbacks);
     }
 
-    if (this.isUnitTest) {
-      this.setupSteps.push(this.setupComponentUnitTest);
-    } else {
-      this.callbacks.subject = function() {
-        throw new Error("component integration tests do not support `subject()`.");
-      };
-      this.setupSteps.push(this.setupComponentIntegrationTest);
-      this.teardownSteps.unshift(this.teardownComponent);
+    switch (this.testType) {
+      case UNIT_TEST:
+        this.setupSteps.push(this.setupComponentUnitTest);
+        break;
+      case LEGACY_INTEGRATION_TEST:
+        this.setupSteps.push(this.setupLegacyComponentTest);
+        this.setupSteps.push(this.setupComponentLegacyIntegrationTest);
+        break;
+      case INTEGRATION_TEST:
+        this.callbacks.subject = function() {
+          throw new Error("component integration tests do not support `subject()`.");
+        };
+        this.setupSteps.push(this.setupComponentIntegrationTest);
+        this.teardownSteps.unshift(this.teardownComponent);
+        break;
+      default:
+        throw new Error("Unexted test type `" + this.testType + "`");
     }
 
     if (Ember.View && Ember.View.views) {
@@ -190,6 +190,70 @@ export default TestModule.extend({
     };
   },
 
+  setupComponentLegacyIntegrationTest: function () {
+    var resolver = getResolver();
+    var namespace = Ember.Object.create({
+      Resolver: { create: function() { return resolver; } }
+    });
+
+    if (Ember.Application.buildRegistry) {
+      var registry;
+      registry = Ember.Application.buildRegistry(namespace);
+      registry.register('component-lookup:main', Ember.ComponentLookup);
+      this.registry = registry;
+      this.container = registry.container();
+    } else {
+      this.container = Ember.Application.buildContainer(namespace);
+      this.container.register('component-lookup:main', Ember.ComponentLookup);
+    }
+  },
+
+  setupLegacyComponentTest: function () {
+    var _this = this;
+    var resolver = getResolver();
+    var container = this.container;
+    var context = this.context;
+
+    var layoutName = 'template:components/' + this.componentName;
+
+    var layout = resolver.resolve(layoutName);
+
+    if (layout) {
+      container.register(layoutName, layout);
+      container.injection(this.subjectName, 'layout', layoutName);
+    }
+
+    context.dispatcher = this.container.lookup('event_dispatcher:main') || Ember.EventDispatcher.create();
+    context.dispatcher.setup({}, '#ember-testing');
+
+    this.callbacks.render = function() {
+      var containerView = Ember.ContainerView.create({container: container});
+      Ember.run(function(){
+        var subject = context.subject();
+        containerView.pushObject(subject);
+        containerView.appendTo('#ember-testing');
+      });
+
+      _this.teardownSteps.unshift(function() {
+        Ember.run(function() {
+          Ember.tryInvoke(containerView, 'destroy');
+        });
+      });
+    };
+
+    this.callbacks.append = function() {
+      Ember.deprecate('this.append() is deprecated. Please use this.render() or this.$() instead.');
+      return context.$();
+    };
+
+    context.$ = function() {
+      this.render();
+      var subject = this.subject();
+
+      return subject.$.apply(subject, arguments);
+    };
+  },
+
   setupContext: function() {
     this._super.call(this);
 
@@ -199,7 +263,7 @@ export default TestModule.extend({
       (this.registry || this.container).injection('component', '_viewRegistry', '-view-registry:main');
     }
 
-    if (!this.isUnitTest) {
+    if (this.isIntegrationTest()) {
       this.context.factory = function() {};
     }
   },

--- a/lib/ember-test-helpers/test-module.js
+++ b/lib/ember-test-helpers/test-module.js
@@ -6,6 +6,10 @@ import buildRegistry from './build-registry';
 import hasEmberVersion from './has-ember-version';
 import { _setupAJAXHooks, _teardownAJAXHooks } from './wait';
 
+export var UNIT_TEST = 0;
+export var LEGACY_INTEGRATION_TEST = 1;
+export var INTEGRATION_TEST = 2;
+
 export default Klass.extend({
   init: function(subjectName, description, callbacks) {
     // Allow `description` to be omitted, in which case it should
@@ -20,13 +24,22 @@ export default Klass.extend({
     this.name = description || subjectName;
     this.callbacks = callbacks || {};
 
-    if (this.callbacks.integration && this.callbacks.needs) {
+    if (callbacks.integration === "legacy") {
+      this.testType = LEGACY_INTEGRATION_TEST;
+    } else if (callbacks.integration) {
+      this.testType = INTEGRATION_TEST;
+    } else {
+      this.testType = UNIT_TEST;
+    }
+
+    delete callbacks.integration;
+
+    if ((this.isIntegrationTest() || this.isLegacyIntegrationTest()) && this.callbacks.needs) {
       throw new Error("cannot declare 'integration: true' and 'needs' in the same module");
     }
 
-    if (this.callbacks.integration) {
-      this.isIntegration = callbacks.integration;
-      delete callbacks.integration;
+    if ((this.isIntegrationTest() || this.isLegacyIntegrationTest()) && this.callbacks.unit) {
+      throw new Error("cannot declare 'integration: true' and 'unit: true'");
     }
 
     this.initSubject();
@@ -88,6 +101,20 @@ export default Klass.extend({
     }
   },
 
+  testType: UNIT_TEST,
+
+  isUnitTest: function () {
+    return this.testType === UNIT_TEST;
+  },
+
+  isIntegrationTest: function () {
+    return this.testType === INTEGRATION_TEST;
+  },
+
+  isLegacyIntegrationTest: function () {
+    return this.testType === LEGACY_INTEGRATION_TEST;
+  },
+
   setup: function() {
     var self = this;
     return self.invokeSteps(self.setupSteps).then(function() {
@@ -127,7 +154,7 @@ export default Klass.extend({
   },
 
   setupContainer: function() {
-    if (this.isIntegration) {
+    if (this.isIntegrationTest() || this.isLegacyIntegrationTest()) {
       this._setupIntegratedContainer();
     } else {
       this._setupIsolatedContainer();

--- a/tests/test-module-for-integration-test.js
+++ b/tests/test-module-for-integration-test.js
@@ -275,3 +275,27 @@ test('still in DOM in willDestroyElement', function() {
     this.render("{{my-component}}");
 
 });
+
+if (! hasEmberVersion(2,0)) {
+  moduleForComponent('my-component', 'Component Legacy Integration Tests', {
+    integration: 'legacy',
+    beforeSetup: function() {
+      setResolverRegistry({
+        'component:my-component': Ember.Component.extend(),
+        'template:components/my-component': Ember.Handlebars.compile(
+          '<span>{{name}}</span>'
+        )
+      });
+    }
+  });
+
+  test('it can render components semantically equivalent to v0.4.3', function(assert) {
+    var component = this.subject({
+      name: 'Ryan Ringler',
+    });
+    this.render();
+
+    equal(this.$('span').text(), 'Ryan Ringler');
+  });
+}
+

--- a/tests/test-module-test.js
+++ b/tests/test-module-test.js
@@ -156,7 +156,7 @@ moduleFor('component:x-foo', 'component:x-foo -- `integration: true`', {
   beforeSetup: function() {
     setupRegistry();
     ok(!this.callbacks.integration, "integration property should be removed from callbacks");
-    ok(this.isIntegration, "isIntegration should be set when we set `integration: true` in callbacks");
+    ok(this.isIntegrationTest(), "isIntegrationTest() should return true we set `integration: true` in callbacks");
   },
   integration: true
 });
@@ -181,6 +181,62 @@ test("throws an error when declaring integration: true and needs in the same mod
   }
 
   ok(result, "should throw an Error when integration: true and needs are provided");
+});
+
+test("throws an error when declaring integration: true and unit:true in the same module", function() {
+  expect(3);
+
+  var result = false;
+
+  try {
+    moduleFor('component:x-foo', {
+      unit: true,
+      integration: true
+    });
+  } catch(err) {
+    result = true;
+  }
+
+  ok(result, "should throw an Error when integration: true and needs are provided");
+});
+
+moduleFor('component:x-foo', 'component:x-foo -- `integration: true` test types', {
+  beforeSetup: function () {
+    equal(this.isUnitTest(), false);
+    equal(this.isIntegrationTest(), true);
+    equal(this.isLegacyIntegrationTest(), false);
+  },
+  integration: true
+});
+
+test("testType functions report the correct test type", function(assert) {
+  ok(true);
+});
+
+moduleFor('component:x-foo', 'component:x-foo -- `unit: true` test types', {
+  beforeSetup: function () {
+    equal(this.isUnitTest(), true);
+    equal(this.isIntegrationTest(), false);
+    equal(this.isLegacyIntegrationTest(), false);
+  },
+  unit: true
+});
+
+test("testType functions report the correct test type", function(assert) {
+  ok(true);
+});
+
+moduleFor('component:x-foo', 'component:x-foo -- `integration: "legacy"` test types', {
+  beforeSetup: function () {
+    equal(this.isUnitTest(), false);
+    equal(this.isIntegrationTest(), false);
+    equal(this.isLegacyIntegrationTest(), true);
+  },
+  integration: "legacy"
+});
+
+test("testType functions report the correct test type", function(assert) {
+  ok(true);
 });
 
 if (hasEmberVersion(1,11)) {


### PR DESCRIPTION
This semantics of the `integration` flag have changed in a
backwards-incompatible way since v0.4.3.  This corresponds to an ember upgrade
(using ember-cli) between v1.12 and v1.13.

In order to ease this upgrade path for ember-cli users, `integration: 'legacy'`
will set up a component test with v0.4.3 semantics.  Of course, newer tests
would still be encouraged to be written with `integration: true`.