### PR TITLE
Add support for owner on ember#canary

### DIFF
--- a/lib/ember-test-helpers/build-registry.js
+++ b/lib/ember-test-helpers/build-registry.js
@@ -56,7 +56,22 @@ export default function(resolver) {
     registry.makeToString = fallbackRegistry.makeToString;
     registry.describe = fallbackRegistry.describe;
 
-    container = registry.container();
+    var owner = {
+      registry: registry,
+      lookup: function () {
+        return this.container.lookup.apply(this.container, arguments);
+      },
+      _lookupFactory: function () {
+        return this.container.lookupFactory.apply(this.container, arguments);
+      },
+      hasRegistration: function () {
+        return this.registry.has.apply(this.registry, arguments);
+      }
+    };
+
+    container = registry.container({ owner: owner });
+
+    owner.container = container;
     exposeRegistryMethodsWithoutDeprecations(container);
   } else {
     container = Ember.Application.buildContainer(namespace);


### PR DESCRIPTION
This resolves https://github.com/emberjs/ember.js/issues/12554 by injecting an owner onto the container that implements the necessary API. (I very well may be missing several API touch points)