### PR TITLE
Work with `Ember.getOwner`.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ sudo: false
 language: node_js
 
 install:
-  - npm install -g bower broccoli-cli
-  - npm install
+  - npm install -g bower
+  - npm install --no-optional
   - bower install
 
 script:

--- a/Brocfile.js
+++ b/Brocfile.js
@@ -17,6 +17,11 @@ var klassy = new Funnel('bower_components', {
   destDir: '/'
 });
 
+var getowner = new Funnel('node_modules/ember-getowner-polyfill/addon', {
+  files: ['fake-owner.js'],
+  destDir: 'ember-test-helpers'
+});
+
 var lib = new Funnel('lib', {
   srcDir: '/',
   include: ['**/*.js'],
@@ -29,7 +34,7 @@ var tests = new Funnel('tests', {
   destDir: '/tests'
 });
 
-var main = mergeTrees([klassy, lib, tests]);
+var main = mergeTrees([klassy, getowner, lib, tests]);
 main = new Babel(main, {
   loose: true,
   moduleIds: true,

--- a/Brocfile.js
+++ b/Brocfile.js
@@ -19,7 +19,7 @@ var klassy = new Funnel('bower_components', {
 
 var getowner = new Funnel('node_modules/ember-getowner-polyfill/addon', {
   files: ['fake-owner.js'],
-  destDir: 'ember-test-helpers'
+  destDir: 'ember-test-helpers/ember-getowner-polyfill'
 });
 
 var lib = new Funnel('lib', {

--- a/Brocfile.js
+++ b/Brocfile.js
@@ -1,31 +1,31 @@
-var pickFiles  = require('broccoli-static-compiler');
+var Funnel = require('broccoli-funnel');
 var mergeTrees = require('broccoli-merge-trees');
 var Babel = require('broccoli-babel-transpiler');
 var concat   = require('broccoli-sourcemap-concat');
 
 // --- Compile ES6 modules ---
 
-var loader = pickFiles('bower_components', {
+var loader = new Funnel('bower_components', {
   srcDir: 'loader.js',
   files: ['loader.js'],
   destDir: '/assets'
 });
 
-var klassy = pickFiles('bower_components', {
+var klassy = new Funnel('bower_components', {
   srcDir: '/klassy/lib',
   files: ['klassy.js'],
   destDir: '/'
 });
 
-var lib = pickFiles('lib', {
+var lib = new Funnel('lib', {
   srcDir: '/',
-  files: ['**/*.js'],
+  include: ['**/*.js'],
   destDir: '/'
 });
 
-var tests = pickFiles('tests', {
+var tests = new Funnel('tests', {
   srcDir: '/',
-  files: ['**/*.js'],
+  include: ['**/*.js'],
   destDir: '/tests'
 });
 
@@ -54,17 +54,13 @@ var vendor = concat('bower_components', {
   outputFile: '/assets/vendor.js'
 });
 
-var pretender = pickFiles('bower_components', {
-
-});
-
-var qunit = pickFiles('bower_components', {
+var qunit = new Funnel('bower_components', {
   srcDir: '/qunit/qunit',
   files: ['qunit.js', 'qunit.css'],
   destDir: '/assets'
 });
 
-var testIndex = pickFiles('tests', {
+var testIndex = new Funnel('tests', {
   srcDir: '/',
   files: ['index.html'],
   destDir: '/tests'

--- a/Brocfile.js
+++ b/Brocfile.js
@@ -1,6 +1,6 @@
 var pickFiles  = require('broccoli-static-compiler');
 var mergeTrees = require('broccoli-merge-trees');
-var compileES6 = require('broccoli-es6modules');
+var Babel = require('broccoli-babel-transpiler');
 var concat   = require('broccoli-sourcemap-concat');
 
 // --- Compile ES6 modules ---
@@ -30,7 +30,11 @@ var tests = pickFiles('tests', {
 });
 
 var main = mergeTrees([klassy, lib, tests]);
-main = new compileES6(main);
+main = new Babel(main, {
+  loose: true,
+  moduleIds: true,
+  modules: 'amdStrict'
+});
 
 main = concat(main, {
   inputFiles: ['**/*.js'],

--- a/lib/ember-test-helpers/build-registry.js
+++ b/lib/ember-test-helpers/build-registry.js
@@ -1,3 +1,5 @@
+import FakeOwner from './ember-getowner-polyfill/fake-owner';
+
 function exposeRegistryMethodsWithoutDeprecations(container) {
   var methods = [
     'register',
@@ -56,22 +58,9 @@ export default function(resolver) {
     registry.makeToString = fallbackRegistry.makeToString;
     registry.describe = fallbackRegistry.describe;
 
-    var owner = {
-      registry: registry,
-      lookup: function () {
-        return this.container.lookup.apply(this.container, arguments);
-      },
-      _lookupFactory: function () {
-        return this.container.lookupFactory.apply(this.container, arguments);
-      },
-      hasRegistration: function () {
-        return this.registry.has.apply(this.registry, arguments);
-      }
-    };
+    container = registry.container();
+    container.owner = new FakeOwner({ container: container });
 
-    container = registry.container({ owner: owner });
-
-    owner.container = container;
     exposeRegistryMethodsWithoutDeprecations(container);
   } else {
     container = Ember.Application.buildContainer(namespace);

--- a/lib/ember-test-helpers/build-registry.js
+++ b/lib/ember-test-helpers/build-registry.js
@@ -56,7 +56,22 @@ export default function(resolver) {
     registry.makeToString = fallbackRegistry.makeToString;
     registry.describe = fallbackRegistry.describe;
 
-    container = registry.container();
+    var owner = {
+      registry: registry,
+      lookup: function () {
+        return this.container.lookup.apply(this.container, arguments);
+      },
+      _lookupFactory: function () {
+        return this.container.lookupFactory.apply(this.container, arguments);
+      },
+      hasRegistration: function () {
+        return this.registry.has.apply(this.registry, arguments);
+      }
+    };
+
+    container = registry.container({ owner: owner });
+
+    owner.container = container;
     exposeRegistryMethodsWithoutDeprecations(container);
   } else {
     container = Ember.Application.buildContainer(namespace);

--- a/lib/ember-test-helpers/test-module.js
+++ b/lib/ember-test-helpers/test-module.js
@@ -156,6 +156,10 @@ export default Klass.extend({
 
     var context = this.context = getContext();
 
+    if (Ember.setOwner) {
+      Ember.setOwner(context, this.container.owner);
+    }
+
     if (Ember.inject) {
       var keys = (Object.keys || Ember.keys)(Ember.inject);
       keys.forEach(function(typeName) {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "broccoli-sourcemap-concat": "^0.4.3",
     "ember-cli": "^0.2.7",
     "ember-cli-release": "^0.2.4",
+    "ember-getowner-polyfill": "^0.1.2",
     "ember-try": "0.0.8",
     "testem": "^0.6.19"
   }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "readmeFilename": "README.md",
   "devDependencies": {
     "broccoli": "^0.13.0",
-    "broccoli-es6modules": "^0.4.0",
+    "broccoli-babel-transpiler": "^5.4.5",
     "broccoli-merge-trees": "^0.1.4",
     "broccoli-sourcemap-concat": "^0.4.3",
     "broccoli-static-compiler": "^0.1.4",

--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
   "devDependencies": {
     "broccoli": "^0.13.0",
     "broccoli-babel-transpiler": "^5.4.5",
+    "broccoli-funnel": "^0.2.13",
     "broccoli-merge-trees": "^0.1.4",
     "broccoli-sourcemap-concat": "^0.4.3",
-    "broccoli-static-compiler": "^0.1.4",
     "ember-cli": "^0.2.7",
     "ember-cli-release": "^0.2.4",
     "ember-try": "0.0.8",

--- a/tests/test-module-test.js
+++ b/tests/test-module-test.js
@@ -1,3 +1,4 @@
+import Ember from 'ember';
 import { TestModule, getContext } from 'ember-test-helpers';
 import hasEmberVersion from 'ember-test-helpers/has-ember-version';
 import test from 'tests/test-support/qunit-test';
@@ -233,5 +234,26 @@ if (hasEmberVersion(1,11)) {
 
     ok(!thing.fromDefaultRegistry, 'should not be found from the default registry');
     ok(thing.notTheDefault, 'found from the overridden factory');
+  });
+}
+
+if (Ember.getOwner) {
+  // this conditional should be changed to `hasEmberVersion` once
+  // `ember-container-inject-owner` lands in a stable version
+
+  moduleFor('foo:thing', 'should be able to use `getOwner` on instances', {
+    beforeSetup: function() {
+      setupRegistry();
+    },
+
+    integration: true
+  });
+
+  test('instances get an owner', function() {
+    var subject = this.subject();
+    var owner = Ember.getOwner(subject);
+
+    var otherThing = owner.lookup('service:other-thing');
+    ok(otherThing.fromDefaultRegistry, 'was able to use `getOwner` on an instance and lookup an instance');
   });
 }

--- a/tests/test-module-test.js
+++ b/tests/test-module-test.js
@@ -256,4 +256,12 @@ if (Ember.getOwner) {
     var otherThing = owner.lookup('service:other-thing');
     ok(otherThing.fromDefaultRegistry, 'was able to use `getOwner` on an instance and lookup an instance');
   });
+
+  test('test context gets an owner', function() {
+    var owner = Ember.getOwner(this);
+
+    var otherThing = owner.lookup('service:other-thing');
+    ok(otherThing.fromDefaultRegistry, 'was able to use `getOwner` on test context and lookup an instance');
+  });
+
 }


### PR DESCRIPTION
* Allows usage of ES6 syntax.
* Remove usage of broccoli-static-compiler.
* Use ember-getowner-polyfill's `fake-owner` to build a mock owner (since there is no way create an owner directly).
* Add tests confirming that `Ember.getOwner` can be used on instances created through the container.
* Add ability to call `Ember.getOwner(this)` on that test context directly (potentially paving the way to deprecate `this.register`, `this.lookup`, and friends).