### PR TITLE
Use newly exposed mixins to create owner.

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -17,11 +17,6 @@ var klassy = new Funnel('bower_components', {
   destDir: '/'
 });
 
-var getowner = new Funnel('node_modules/ember-getowner-polyfill/addon', {
-  files: ['fake-owner.js'],
-  destDir: 'ember-test-helpers/ember-getowner-polyfill'
-});
-
 var lib = new Funnel('lib', {
   srcDir: '/',
   include: ['**/*.js'],
@@ -34,7 +29,7 @@ var tests = new Funnel('tests', {
   destDir: '/tests'
 });
 
-var main = mergeTrees([klassy, getowner, lib, tests]);
+var main = mergeTrees([klassy, lib, tests]);
 main = new Babel(main, {
   loose: true,
   moduleIds: true,

--- a/lib/ember-test-helpers/build-registry.js
+++ b/lib/ember-test-helpers/build-registry.js
@@ -1,4 +1,4 @@
-import FakeOwner from './ember-getowner-polyfill/fake-owner';
+import Ember from 'ember';
 
 function exposeRegistryMethodsWithoutDeprecations(container) {
   var methods = [
@@ -27,6 +27,14 @@ function exposeRegistryMethodsWithoutDeprecations(container) {
     exposeRegistryMethod(container, methods[i]);
   }
 }
+
+var Owner = (function() {
+  if (Ember._RegistryProxyMixin && Ember._ContainerProxyMixin) {
+    return Ember.Object.extend(Ember._RegistryProxyMixin, Ember._ContainerProxyMixin);
+  }
+
+  return Ember.Object.extend();
+})();
 
 export default function(resolver) {
   var fallbackRegistry, registry, container;
@@ -58,8 +66,13 @@ export default function(resolver) {
     registry.makeToString = fallbackRegistry.makeToString;
     registry.describe = fallbackRegistry.describe;
 
-    container = registry.container();
-    container.owner = new FakeOwner({ container: container });
+    var owner = Owner.create({
+      __registry__: registry,
+      __container__: null
+    });
+
+    container = registry.container({ owner: owner });
+    owner.__container__ = container;
 
     exposeRegistryMethodsWithoutDeprecations(container);
   } else {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "broccoli-sourcemap-concat": "^0.4.3",
     "ember-cli": "^0.2.7",
     "ember-cli-release": "^0.2.4",
-    "ember-getowner-polyfill": "^0.1.2",
     "ember-try": "0.0.8",
     "testem": "^0.6.19"
   }


### PR DESCRIPTION
This is much less brittle than relying on the polyfill for forward/future support.