### PR TITLE
Add support for `integration: 'legacy'`

### DIFF
--- a/lib/ember-test-helpers/test-module-for-component.js
+++ b/lib/ember-test-helpers/test-module-for-component.js
@@ -30,17 +30,17 @@ export default TestModule.extend({
       this.isUnitTest = true;
     }
 
-    if (!this.isUnitTest) {
-      callbacks.integration = true;
-    }
-
     if (description) {
       this._super.call(this, 'component:' + componentName, description, callbacks);
     } else {
       this._super.call(this, 'component:' + componentName, callbacks);
     }
 
-    if (this.isUnitTest) {
+    if (!this.isUnitTest && !this.isLegacy) {
+      callbacks.integration = true;
+    }
+
+    if (this.isUnitTest || this.isLegacy) {
       this.setupSteps.push(this.setupComponentUnitTest);
     } else {
       this.callbacks.subject = function() {
@@ -199,7 +199,7 @@ export default TestModule.extend({
       (this.registry || this.container).injection('component', '_viewRegistry', '-view-registry:main');
     }
 
-    if (!this.isUnitTest) {
+    if (!this.isUnitTest && !this.isLegacy) {
       this.context.factory = function() {};
     }
   },

--- a/lib/ember-test-helpers/test-module.js
+++ b/lib/ember-test-helpers/test-module.js
@@ -25,7 +25,8 @@ export default Klass.extend({
     }
 
     if (this.callbacks.integration) {
-      this.isIntegration = callbacks.integration;
+      this.isLegacy = (callbacks.integration === 'legacy');
+      this.isIntegration = (callbacks.integration !== 'legacy');
       delete callbacks.integration;
     }
 
@@ -127,7 +128,7 @@ export default Klass.extend({
   },
 
   setupContainer: function() {
-    if (this.isIntegration) {
+    if (this.isIntegration || this.isLegacy) {
       this._setupIntegratedContainer();
     } else {
       this._setupIsolatedContainer();

--- a/tests/test-module-for-integration-test.js
+++ b/tests/test-module-for-integration-test.js
@@ -275,3 +275,26 @@ test('still in DOM in willDestroyElement', function() {
     this.render("{{my-component}}");
 
 });
+
+if (! hasEmberVersion(2,0)) {
+  moduleForComponent('my-component', 'Component Legacy Integration Tests', {
+    integration: 'legacy',
+    beforeSetup: function() {
+      setResolverRegistry({
+        'component:my-component': Ember.Component.extend(),
+        'template:components/my-component': Ember.Handlebars.compile(
+          '<span>{{name}}</span>'
+        )
+      });
+    }
+  });
+
+  test('it can render components semantically equivalent to v0.4.3', function(assert) {
+    var component = this.subject({
+      name: 'Charles XII',
+    });
+    this.render();
+
+    equal(this.$('span').text(), 'Charles XII');
+  });
+}


### PR DESCRIPTION
This semantics of the `integration` flag have changed in a backwards-incompatible way since v0.4.3.  This corresponds to an ember upgrade (using ember-cli) between v1.12 and v1.13.

In order to ease this upgrade path for ember-cli users, `integration: 'legacy'` will set up a component test with v0.4.3 semantics.  Of course, newer tests would still be encouraged to be written with `integration: true`.

---

Replacement PR for https://github.com/switchfly/ember-test-helpers/pull/115.

/cc @hjdivad