### PR TITLE
Restrict integration: 'legacy' to component tests.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -25,14 +25,14 @@
   ],
   "dependencies": {
     "klassy": "cerebris/klassy.js#0.1.0",
-    "ember": "^1.13.0"
+    "ember": "^2.2.0"
   },
   "devDependencies": {
     "qunit": "^1.15.0",
-    "ember-data": "1.13.9",
+    "ember-data": "^2.2.0",
     "pretender": "~0.10.1",
     "loader.js": "ember-cli/loader.js#3.0.0",
-    "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
+    "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.6",
     "ember-cli-test-loader": "rwjblue/ember-cli-test-loader#0.0.4",
     "jquery": "~2.1.1"
   }

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -31,6 +31,9 @@ module.exports = {
       name: 'ember-1.13',
       dependencies: {
         "ember": "~1.13.8"
+      },
+      devDependencies: {
+        "ember-data": "~1.0.0-beta.19.2"
       }
     },
     {
@@ -39,7 +42,25 @@ module.exports = {
         "ember": "~2.0.0"
       },
       devDependencies: {
-        "ember-data": "~2.0.0-beta.2"
+        "ember-data": "~2.0.0"
+      }
+    },
+    {
+      name: 'ember-2.1',
+      dependencies: {
+        "ember": "~2.1.0"
+      },
+      devDependencies: {
+        "ember-data": "~2.1.0"
+      }
+    },
+    {
+      name: 'ember-2.2',
+      dependencies: {
+        "ember": "~2.2.0"
+      },
+      devDependencies: {
+        "ember-data": "~2.2.0"
       }
     },
     {
@@ -48,7 +69,7 @@ module.exports = {
         "ember": "components/ember#release"
       },
       devDependencies: {
-        "ember-data": "~2.0.0"
+        "ember-data": "~2.2.0"
       },
       resolutions: {
         "ember": "release"
@@ -60,7 +81,7 @@ module.exports = {
         "ember": "components/ember#beta"
       },
       devDependencies: {
-        "ember-data": "~2.0.0"
+        "ember-data": "~2.2.0"
       },
       resolutions: {
         "ember": "beta"
@@ -72,7 +93,7 @@ module.exports = {
         "ember": "components/ember#canary"
       },
       devDependencies: {
-        "ember-data": "~2.0.0"
+        "ember-data": "~2.2.0"
       },
       resolutions: {
         "ember": "canary"

--- a/lib/ember-test-helpers/test-module-for-component.js
+++ b/lib/ember-test-helpers/test-module-for-component.js
@@ -3,6 +3,8 @@ import Ember from 'ember';
 import { getResolver } from './test-resolver';
 
 export default TestModule.extend({
+  isComponentTestModule: true,
+
   init: function(componentName, description, callbacks) {
     // Allow `description` to be omitted
     if (!callbacks && typeof description === 'object') {

--- a/lib/ember-test-helpers/test-module.js
+++ b/lib/ember-test-helpers/test-module.js
@@ -25,8 +25,16 @@ export default Klass.extend({
     }
 
     if (this.callbacks.integration) {
-      this.isLegacy = (callbacks.integration === 'legacy');
-      this.isIntegration = (callbacks.integration !== 'legacy');
+      if (this.isComponentTestModule) {
+        this.isLegacy = (callbacks.integration === 'legacy');
+        this.isIntegration = (callbacks.integration !== 'legacy');
+      } else {
+        if (callbacks.integration === 'legacy') {
+          throw new Error('`integration: \'legacy\'` is only valid for component tests.');
+        }
+        this.isIntegration = true;
+      }
+
       delete callbacks.integration;
     }
 

--- a/tests/test-module-test.js
+++ b/tests/test-module-test.js
@@ -153,7 +153,7 @@ test("needs gets us the component we need", function() {
   ok(otherComponent, "another component can be resolved when it's in our needs array");
 });
 
-moduleFor('component:x-foo', 'component:x-foo -- `integration: true`', {
+moduleFor('component:x-foo', 'component:x-foo -- `integration`', {
   beforeSetup: function() {
     setupRegistry();
     ok(!this.callbacks.integration, "integration property should be removed from callbacks");
@@ -182,6 +182,22 @@ test("throws an error when declaring integration: true and needs in the same mod
   }
 
   ok(result, "should throw an Error when integration: true and needs are provided");
+});
+
+test("throws an error when declaring integration: 'legacy' in `moduleFor` test", function() {
+  expect(3);
+
+  var result = false;
+
+  try {
+    moduleFor('component:x-foo', {
+      integration: 'legacy'
+    });
+  } catch(err) {
+    result = true;
+  }
+
+  ok(result, "should throw an Error when integration: 'legacy' outside of a component integration test");
 });
 
 if (hasEmberVersion(1,11)) {

--- a/tests/test-module-test.js
+++ b/tests/test-module-test.js
@@ -253,10 +253,7 @@ if (hasEmberVersion(1,11)) {
   });
 }
 
-if (Ember.getOwner) {
-  // this conditional should be changed to `hasEmberVersion` once
-  // `ember-container-inject-owner` lands in a stable version
-
+if (hasEmberVersion(2, 3)) {
   moduleFor('foo:thing', 'should be able to use `getOwner` on instances', {
     beforeSetup: function() {
       setupRegistry();
@@ -279,5 +276,4 @@ if (Ember.getOwner) {
     var otherThing = owner.lookup('service:other-thing');
     ok(otherThing.fromDefaultRegistry, 'was able to use `getOwner` on test context and lookup an instance');
   });
-
 }


### PR DESCRIPTION
The meaning of `integration: true` has been the same for non-component
tests, so only allow usage of `legacy` when using a component test.

---

Update default dependencies & ember-try config.

* Update default dependencies (makes `ember test` run against current
 release).
* Add 2.1.0 to ember-try config.
* Add 2.2.0 to ember-try config.
* Use associated Ember Data with each respective Ember release.