### PR TITLE
Add moduleForAcceptance

### DIFF
--- a/lib/ember-test-helpers.js
+++ b/lib/ember-test-helpers.js
@@ -1,7 +1,8 @@
-import Ember                  from 'ember';
-import TestModule             from 'ember-test-helpers/test-module';
+import Ember from 'ember';
+import TestModule from 'ember-test-helpers/test-module';
+import TestModuleForAcceptance from 'ember-test-helpers/test-module-for-acceptance';
 import TestModuleForComponent from 'ember-test-helpers/test-module-for-component';
-import TestModuleForModel     from 'ember-test-helpers/test-module-for-model';
+import TestModuleForModel from 'ember-test-helpers/test-module-for-model';
 import { getContext, setContext } from 'ember-test-helpers/test-context';
 import { setResolver } from 'ember-test-helpers/test-resolver';
 
@@ -9,6 +10,7 @@ Ember.testing = true;
 
 export {
   TestModule,
+  TestModuleForAcceptance,
   TestModuleForComponent,
   TestModuleForModel,
   getContext,

--- a/lib/ember-test-helpers/abstract-test-module.js
+++ b/lib/ember-test-helpers/abstract-test-module.js
@@ -1,0 +1,135 @@
+import { Klass } from 'klassy';
+import { _setupAJAXHooks, _teardownAJAXHooks } from './wait';
+import { setContext, unsetContext } from './test-context';
+
+import Ember from 'ember';
+
+export default Klass.extend({
+  init(description, options) {
+    this.description = description;
+    this.callbacks = options || {};
+
+    this.initSetupSteps();
+    this.initTeardownSteps();
+  },
+
+  setup(assert) {
+    return this.invokeSteps(this.setupSteps, this, assert).then(() => {
+      this.contextualizeCallbacks();
+      return this.invokeSteps(this.contextualizedSetupSteps, this.context, assert);
+    });
+  },
+
+  teardown(assert) {
+    return this.invokeSteps(this.contextualizedTeardownSteps, this.context, assert).then(() => {
+      return this.invokeSteps(this.teardownSteps, this, assert);
+    }).then(() => {
+      this.cache = null;
+      this.cachedCalls = null;
+    });
+  },
+
+  initSetupSteps() {
+    this.setupSteps = [];
+    this.contextualizedSetupSteps = [];
+
+    if (this.callbacks.beforeSetup) {
+      this.setupSteps.push( this.callbacks.beforeSetup );
+      delete this.callbacks.beforeSetup;
+    }
+
+    this.setupSteps.push(this.setupContext);
+    this.setupSteps.push(this.setupTestElements);
+    this.setupSteps.push(this.setupAJAXListeners);
+
+    if (this.callbacks.setup) {
+      this.contextualizedSetupSteps.push( this.callbacks.setup );
+      delete this.callbacks.setup;
+    }
+  },
+
+  invokeSteps(steps, context, assert) {
+    steps = steps.slice();
+
+    function nextStep() {
+      var step = steps.shift();
+      if (step) {
+        // guard against exceptions, for example missing components referenced from needs.
+        return new Ember.RSVP.Promise((resolve) => {
+          resolve(step.call(context, assert));
+        }).then(nextStep);
+      } else {
+        return Ember.RSVP.resolve();
+      }
+    }
+    return nextStep();
+  },
+
+  contextualizeCallbacks() {
+
+  },
+
+  initTeardownSteps() {
+    this.teardownSteps = [];
+    this.contextualizedTeardownSteps = [];
+
+    if (this.callbacks.teardown) {
+      this.contextualizedTeardownSteps.push( this.callbacks.teardown );
+      delete this.callbacks.teardown;
+    }
+
+    this.teardownSteps.push(this.teardownContext);
+    this.teardownSteps.push(this.teardownTestElements);
+    this.teardownSteps.push(this.teardownAJAXListeners);
+
+    if (this.callbacks.afterTeardown) {
+      this.teardownSteps.push( this.callbacks.afterTeardown );
+      delete this.callbacks.afterTeardown;
+    }
+  },
+
+  setupTestElements() {
+    if (Ember.$('#ember-testing').length === 0) {
+      Ember.$('<div id="ember-testing"/>').appendTo(document.body);
+    }
+  },
+
+  setupContext(options) {
+    var config = Ember.merge({
+      dispatcher: null,
+      inject: {}
+    }, options);
+
+    setContext(config);
+  },
+
+  setupAJAXListeners() {
+    _setupAJAXHooks();
+  },
+
+  teardownAJAXListeners() {
+    _teardownAJAXHooks();
+  },
+
+  teardownTestElements() {
+    Ember.$('#ember-testing').empty();
+
+    // Ember 2.0.0 removed Ember.View as public API, so only do this when
+    // Ember.View is present
+    if (Ember.View && Ember.View.views) {
+      Ember.View.views = {};
+    }
+  },
+
+  teardownContext() {
+    var context = this.context;
+    this.context = undefined;
+    unsetContext();
+
+    if (context && context.dispatcher && !context.dispatcher.isDestroyed) {
+      Ember.run(function() {
+        context.dispatcher.destroy();
+      });
+    }
+  }
+});

--- a/lib/ember-test-helpers/test-module-for-acceptance.js
+++ b/lib/ember-test-helpers/test-module-for-acceptance.js
@@ -1,0 +1,30 @@
+import AbstractTestModule from './abstract-test-module';
+import Ember from 'ember';
+import { getContext } from './test-context';
+
+export default AbstractTestModule.extend({
+  setupContext() {
+    this._super({ application: this.createApplication() });
+  },
+
+  teardownContext() {
+    Ember.run(() => {
+      getContext().application.destroy();
+    });
+
+    this._super();
+  },
+
+  createApplication() {
+    let { Application, config } = this.callbacks;
+    let application;
+
+    Ember.run(() => {
+      application = Application.create(config);
+      application.setupForTesting();
+      application.injectTestHelpers();
+    });
+
+    return application;
+  }
+});

--- a/lib/ember-test-helpers/test-module.js
+++ b/lib/ember-test-helpers/test-module.js
@@ -1,12 +1,11 @@
 import Ember from 'ember';
-import { getContext, setContext, unsetContext } from './test-context';
-import { Klass } from 'klassy';
+import { getContext } from './test-context';
+import AbstractTestModule from './abstract-test-module';
 import { getResolver } from './test-resolver';
 import buildRegistry from './build-registry';
 import hasEmberVersion from './has-ember-version';
-import { _setupAJAXHooks, _teardownAJAXHooks } from './wait';
 
-export default Klass.extend({
+export default AbstractTestModule.extend({
   init: function(subjectName, description, callbacks) {
     // Allow `description` to be omitted, in which case it should
     // default to `subjectName`
@@ -97,44 +96,6 @@ export default Klass.extend({
     }
   },
 
-  setup: function() {
-    var self = this;
-    return self.invokeSteps(self.setupSteps).then(function() {
-      self.contextualizeCallbacks();
-      return self.invokeSteps(self.contextualizedSetupSteps, self.context);
-    });
-  },
-
-  teardown: function() {
-    var self = this;
-    return self.invokeSteps(self.contextualizedTeardownSteps, self.context).then(function() {
-      return self.invokeSteps(self.teardownSteps);
-    }).then(function() {
-      self.cache = null;
-      self.cachedCalls = null;
-    });
-  },
-
-  invokeSteps: function(steps, _context) {
-    var context = _context;
-    if (!context) {
-      context = this;
-    }
-    steps = steps.slice();
-    function nextStep() {
-      var step = steps.shift();
-      if (step) {
-        // guard against exceptions, for example missing components referenced from needs.
-        return new Ember.RSVP.Promise(function(ok) {
-          ok(step.call(context));
-        }).then(nextStep);
-      } else {
-        return Ember.RSVP.resolve();
-      }
-    }
-    return nextStep();
-  },
-
   setupContainer: function() {
     if (this.isIntegration || this.isLegacy) {
       this._setupIntegratedContainer();
@@ -151,16 +112,14 @@ export default Klass.extend({
       return container.lookupFactory(subjectName);
     };
 
-    setContext({
+    this._super({
       container:  this.container,
       registry: this.registry,
       factory:    factory,
-      dispatcher: null,
       register: function() {
         var target = this.registry || this.container;
         return target.register.apply(target, arguments);
       },
-      inject: {}
     });
 
     var context = this.context = getContext();
@@ -180,16 +139,6 @@ export default Klass.extend({
     }
   },
 
-  setupTestElements: function() {
-    if (Ember.$('#ember-testing').length === 0) {
-      Ember.$('<div id="ember-testing"/>').appendTo(document.body);
-    }
-  },
-
-  setupAJAXListeners: function() {
-    _setupAJAXHooks();
-  },
-
   teardownSubject: function() {
     var subject = this.cache.subject;
 
@@ -205,32 +154,6 @@ export default Klass.extend({
     Ember.run(function() {
       container.destroy();
     });
-  },
-
-  teardownContext: function() {
-    var context = this.context;
-    this.context = undefined;
-    unsetContext();
-
-    if (context.dispatcher && !context.dispatcher.isDestroyed) {
-      Ember.run(function() {
-        context.dispatcher.destroy();
-      });
-    }
-  },
-
-  teardownTestElements: function() {
-    Ember.$('#ember-testing').empty();
-
-    // Ember 2.0.0 removed Ember.View as public API, so only do this when
-    // Ember.View is present
-    if (Ember.View && Ember.View.views) {
-      Ember.View.views = {};
-    }
-  },
-
-  teardownAJAXListeners: function() {
-    _teardownAJAXHooks();
   },
 
   defaultSubject: function(options, factory) {

--- a/tests/test-module-for-acceptance-test.js
+++ b/tests/test-module-for-acceptance-test.js
@@ -1,0 +1,72 @@
+import Ember from 'ember';
+import { TestModuleForAcceptance } from 'ember-test-helpers';
+import test from 'tests/test-support/qunit-test';
+import qunitModuleFor from 'tests/test-support/qunit-module-for';
+import Resolver, { setResolverRegistry } from 'tests/test-support/resolver';
+import { getContext } from 'ember-test-helpers/test-context';
+
+function moduleForAcceptance(description, callbacks) {
+  qunitModuleFor(new TestModuleForAcceptance(description, callbacks));
+}
+
+let Application = Ember.Application.extend({
+  rootElement: '#ember-testing',
+  Resolver
+});
+
+moduleForAcceptance('TestModuleForAcceptance | Lifecycle', {
+  Application,
+
+  beforeSetup(assert) {
+    assert.expect(6);
+    assert.strictEqual(getContext(), undefined);
+
+    setResolverRegistry({
+      'router:main': Ember.Router.extend({ location: 'none' })
+    });
+  },
+
+  setup(assert) {
+    assert.ok(getContext().application instanceof Ember.Application);
+  },
+
+  teardown(assert) {
+    assert.ok(getContext().application instanceof Ember.Application);
+  },
+
+  afterTeardown(assert) {
+    assert.strictEqual(getContext(), undefined);
+    assert.strictEqual(Ember.$('#ember-testing').children().length, 0);
+  }
+});
+
+test('Lifecycle is correct', function() {
+  ok(true);
+});
+
+moduleForAcceptance('TestModuleForAcceptance | Basic acceptance tests', {
+  Application,
+
+  beforeSetup() {
+    setResolverRegistry({
+      'router:main': Ember.Router.extend({ location: 'none' }),
+      'template:index': Ember.Handlebars.compile('This is the index page.')
+    });
+  }
+});
+
+test('Basic acceptance test using instance test helpers', function() {
+  this.application.testHelpers.visit('/');
+
+  this.application.testHelpers.andThen(function() {
+    equal(Ember.$('#ember-testing').text(), 'This is the index page.');
+  });
+});
+
+test('Basic acceptance test using global test helpers', function() {
+  window.visit('/');
+
+  window.andThen(function() {
+    equal(Ember.$('#ember-testing').text(), 'This is the index page.');
+  });
+});

--- a/tests/test-support/qunit-module-for.js
+++ b/tests/test-support/qunit-module-for.js
@@ -2,11 +2,11 @@ export default function qunitModuleFor(module) {
   QUnit.module(module.name, {
     setup: function(assert) {
       var done = assert.async();
-      module.setup()['finally'](done);
+      module.setup(assert)['finally'](done);
     },
     teardown: function(assert) {
       var done = assert.async();
-      module.teardown()['finally'](done);
+      module.teardown(assert)['finally'](done);
     }
   });
 }

--- a/tests/test-support/resolver.js
+++ b/tests/test-support/resolver.js
@@ -5,7 +5,7 @@ var Resolver = Ember.DefaultResolver.extend({
   registry: null,
 
   resolve: function(fullName) {
-    return this.registry[fullName] || this._super.apply(this, arguments);
+    return this.registry[fullName];
   },
 
   normalize: function(fullName) {
@@ -19,3 +19,9 @@ setResolver(resolver);
 export function setResolverRegistry(registry) {
   resolver.set('registry', registry);
 }
+
+export default {
+  create() {
+    return resolver;
+  }
+};


### PR DESCRIPTION
# Problem
Currently the behavior necessary for starting and tearing down Ember apps in tests is located in [blueprints](https://github.com/ember-cli/ember-cli/blob/master/blueprints/app/files/tests/helpers/module-for-acceptance.js). Blueprints expose the user to complexity and create extra boilerplate.

# Solution
Create a `TestModuleForApplication` helper. This:
 1. avoids the use of blueprints
 2. gives the ember team a natural way to pass testing improvements down to users
 3. prevents the user from accessing the `testApp` directly in an acceptance test
 4. brings hooks for writing tests to a single location. This improves documentation and creates a stronger separation of concerns between blueprints and tests

# Design
First we pulled out a  `AbstractTestModule`. This is a place to put shared behavior between `TestModule` and `TestModuleForApplication`. It also helps crystalize what needs to be implemented in order to be a 'TestModule'. Next, we implemented a `TestModuleForApplication`. The name 'TestModuleForApplication' was chosen to extend the naming pattern already defined. An acceptance test needs an application, just as a component needs an integration.  

`TestModuleForApplication` does several things. It sets up and tears down a testApp. It provides four temporal hooks, `beforeSetup`/`afterTeardown`, which allow a user of the module to do things before and after the test app is created, and `setup`/`teardown` which both execute while the app is running.

`TestModuleForApplication` provides options for the user of the module to customize the test app. The `Application` option which allows you to define what the test app will be, and a `config` where you can specify things like the `rootElement`. 
