### PR TITLE
Change callback context to deprecate test module properties

### DIFF
--- a/lib/ember-test-helpers/test-module.js
+++ b/lib/ember-test-helpers/test-module.js
@@ -246,13 +246,17 @@ export default Klass.extend({
     this.cachedCalls = this.cachedCalls || {};
 
     var keys = (Object.keys || Ember.keys)(callbacks);
+    var keysLength = keys.length;
 
-    for (var i = 0, l = keys.length; i < l; i++) {
-      this._contextualizeCallback(context, keys[i]);
+    if (keysLength) {
+      var deprecatedContext = this._buildDeprecatedContext(this, context);
+      for (var i = 0; i < keysLength; i++) {
+        this._contextualizeCallback(context, keys[i], deprecatedContext);
+      }
     }
   },
 
-  _contextualizeCallback: function(context, key) {
+  _contextualizeCallback: function(context, key, callbackContext) {
     var _this     = this;
     var callbacks = this.callbacks;
     var factory   = context.factory;
@@ -260,13 +264,43 @@ export default Klass.extend({
     context[key] = function(options) {
       if (_this.cachedCalls[key]) { return _this.cache[key]; }
 
-      var result = callbacks[key].call(_this, options, factory());
+      var result = callbacks[key].call(callbackContext, options, factory());
 
       _this.cache[key] = result;
       _this.cachedCalls[key] = true;
 
       return result;
     };
+  },
+
+  /*
+    Builds a version of the passed in context that contains deprecation warnings
+    for accessing properties that exist on the module.
+  */
+  _buildDeprecatedContext: function(module, context) {
+    var deprecatedContext = Object.create(context);
+
+    var keysForDeprecation = Object.keys(module);
+
+    for (var i = 0, l = keysForDeprecation.length; i < l; i++) {
+      this._proxyDeprecation(module, deprecatedContext, keysForDeprecation[i]);
+    }
+
+    return deprecatedContext;
+  },
+
+  /*
+    Defines a key on an object to act as a proxy for deprecating the original.
+  */
+  _proxyDeprecation: function(obj, proxy, key) {
+    if (typeof proxy[key] === 'undefined') {
+      Object.defineProperty(proxy, key, {
+        get: function() {
+          Ember.deprecate('Accessing the test module property "' + key + '" from a callback is deprecated.', false, { id: 'ember-test-helpers.test-module.callback-context', until: '0.6.0' });
+          return obj[key];
+        }
+      });
+    }
   },
 
   _setupContainer: function(isolated) {


### PR DESCRIPTION
Addresses #133.

One note: in the case where a user-defined context property collides with a property on the test module, nothing special is done since the user-defined value isn't added to the context until after binding the callbacks.