### PR TITLE
Make build-registry work correctly when ember-data addon is used

### DIFF
--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -98,6 +98,18 @@ module.exports = {
       resolutions: {
         "ember": "canary"
       }
+    },
+    {
+      name: 'ember-data-2.3',
+      dependencies: {
+        "ember": "components/ember#release",
+      },
+      devDependencies: {
+        "ember-data": "~2.3"
+      },
+      resolutions: {
+        "ember": "release"
+      }
     }
   ]
 };

--- a/lib/ember-test-helpers/build-registry.js
+++ b/lib/ember-test-helpers/build-registry.js
@@ -1,4 +1,4 @@
-/* globals global, self */
+/* globals global, self, requirejs, require */
 
 import Ember from 'ember';
 
@@ -98,7 +98,15 @@ export default function(resolver) {
   }
 
   var globalContext = typeof global === 'object' && global || self;
-  if (globalContext.DS) {
+  if (requirejs.entries['ember-data/setup-container']) {
+    // ember-data is a proper ember-cli addon since 2.3; if no 'import
+    // 'ember-data'' is present somewhere in the tests, there is also no `DS`
+    // available on the globalContext and hence ember-data wouldn't be setup
+    // correctly for the tests; that's why we import and call setupContainer
+    // here; also see https://github.com/emberjs/data/issues/4071 for context
+    var setupContainer = require('ember-data/setup-container')['default'];
+    setupContainer(registry || container);
+  } else if (globalContext.DS) {
     var DS = globalContext.DS;
     if (DS._setupContainer) {
       DS._setupContainer(registry || container);


### PR DESCRIPTION
Credit for fix code goes to @rwjblue, I am merely the humble PR creator.

This addresses emberjs/data#4071.