### PR TITLE
Add support for Ember Test registered waiters to wait helper

### DIFF
--- a/lib/ember-test-helpers/wait.js
+++ b/lib/ember-test-helpers/wait.js
@@ -43,7 +43,9 @@ export default function wait(_options) {
         return;
       }
 
-      if (waitForWaiters && (Ember.Test.waiters && Ember.Test.waiters.any(([context, callback]) => !callback.call(context)))) {
+      if (waitForWaiters && Ember.Test.waiters && Ember.Test.waiters.any(([context, callback]) => {
+            return !callback.call(context);
+          })) {
         return;
       }
 

--- a/lib/ember-test-helpers/wait.js
+++ b/lib/ember-test-helpers/wait.js
@@ -31,6 +31,7 @@ export default function wait(_options) {
   var options = _options || {};
   var waitForTimers = options.hasOwnProperty('waitForTimers') ? options.waitForTimers : true;
   var waitForAJAX = options.hasOwnProperty('waitForAJAX') ? options.waitForAJAX : true;
+  var waitForWaiters = options.hasOwnProperty('waitForWaiters') ? options.waitForWaiters : true;
 
   return new Ember.RSVP.Promise(function(resolve) {
     var watcher = self.setInterval(function() {
@@ -39,6 +40,10 @@ export default function wait(_options) {
       }
 
       if (waitForAJAX && requests && requests.length > 0) {
+        return;
+      }
+
+      if (waitForWaiters && (Ember.Test.waiters && Ember.Test.waiters.any(([context, callback]) => !callback.call(context)))) {
         return;
       }
 


### PR DESCRIPTION
Adds support for Ember Test registered waiters (http://emberjs.com/api/classes/Ember.Test.html#method_registerWaiter)

See #139 