### PR TITLE
Avoid using DS.JSONAPIAdapter if module is present.

### DIFF
--- a/lib/ember-test-helpers/test-module-for-model.js
+++ b/lib/ember-test-helpers/test-module-for-model.js
@@ -22,7 +22,13 @@ export default TestModule.extend({
     if (!adapterFactory) {
       if (requirejs.entries['ember-data/adapters/json-api']) {
         adapterFactory = require('ember-data/adapters/json-api')['default'];
-      } else {
+      }
+
+      // when ember-data/adapters/json-api is provided via ember-cli shims
+      // using Ember Data 1.x the actual JSONAPIAdapter isn't found, but the
+      // above require statement returns a bizzaro object with only a `default`
+      // property (circular reference actually)
+      if (!adapterFactory || !adapterFactory.create) {
         adapterFactory = DS.JSONAPIAdapter || DS.FixtureAdapter;
       }
 

--- a/lib/ember-test-helpers/test-module-for-model.js
+++ b/lib/ember-test-helpers/test-module-for-model.js
@@ -20,7 +20,11 @@ export default TestModule.extend({
 
     var adapterFactory = container.lookupFactory('adapter:application');
     if (!adapterFactory) {
-      adapterFactory = DS.JSONAPIAdapter || DS.FixtureAdapter;
+      if (requirejs.entries['ember-data/adapters/json-api']) {
+        adapterFactory = require('ember-data/adapters/json-api')['default'];
+      } else {
+        adapterFactory = DS.JSONAPIAdapter || DS.FixtureAdapter;
+      }
 
       var thingToRegisterWith = this.registry || this.container;
       thingToRegisterWith.register('adapter:application', adapterFactory);

--- a/lib/ember-test-helpers/test-module-for-model.js
+++ b/lib/ember-test-helpers/test-module-for-model.js
@@ -1,4 +1,4 @@
-/* global DS */ // added here to prevent an import from erroring when ED is not present
+/* global DS, require, requirejs */ // added here to prevent an import from erroring when ED is not present
 
 import TestModule from './test-module';
 import Ember from 'ember';


### PR DESCRIPTION
Replaces https://github.com/switchfly/ember-test-helpers/pull/142.