### PR TITLE
Add moduleForIntegration

### DIFF
--- a/lib/ember-test-helpers.js
+++ b/lib/ember-test-helpers.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import TestModule from 'ember-test-helpers/test-module';
 import TestModuleForAcceptance from 'ember-test-helpers/test-module-for-acceptance';
+import TestModuleForIntegration from 'ember-test-helpers/test-module-for-integration';
 import TestModuleForComponent from 'ember-test-helpers/test-module-for-component';
 import TestModuleForModel from 'ember-test-helpers/test-module-for-model';
 import { getContext, setContext } from 'ember-test-helpers/test-context';
@@ -11,6 +12,7 @@ Ember.testing = true;
 export {
   TestModule,
   TestModuleForAcceptance,
+  TestModuleForIntegration,
   TestModuleForComponent,
   TestModuleForModel,
   getContext,

--- a/lib/ember-test-helpers/abstract-test-module.js
+++ b/lib/ember-test-helpers/abstract-test-module.js
@@ -5,8 +5,8 @@ import { setContext, unsetContext } from './test-context';
 import Ember from 'ember';
 
 export default Klass.extend({
-  init(description, options) {
-    this.description = description;
+  init(name, options) {
+    this.name = name;
     this.callbacks = options || {};
 
     this.initSetupSteps();

--- a/lib/ember-test-helpers/test-module-for-integration.js
+++ b/lib/ember-test-helpers/test-module-for-integration.js
@@ -1,0 +1,259 @@
+import Ember from 'ember';
+import { getContext } from './test-context';
+import AbstractTestModule from './abstract-test-module';
+import { getResolver } from './test-resolver';
+import buildRegistry from './build-registry';
+import hasEmberVersion from './has-ember-version';
+
+export default AbstractTestModule.extend({
+  initSetupSteps() {
+    this.setupSteps = [];
+    this.contextualizedSetupSteps = [];
+
+    if (this.callbacks.beforeSetup) {
+      this.setupSteps.push( this.callbacks.beforeSetup );
+      delete this.callbacks.beforeSetup;
+    }
+
+    this.setupSteps.push(this.setupContainer);
+    this.setupSteps.push(this.setupContext);
+    this.setupSteps.push(this.setupTestElements);
+    this.setupSteps.push(this.setupAJAXListeners);
+    this.setupSteps.push(this.setupComponentIntegrationTest);
+
+    if (Ember.View && Ember.View.views) {
+      this.setupSteps.push(this._aliasViewRegistry);
+    }
+
+    if (this.callbacks.setup) {
+      this.contextualizedSetupSteps.push(this.callbacks.setup);
+      delete this.callbacks.setup;
+    }
+  },
+
+  initTeardownSteps() {
+    this.teardownSteps = [];
+    this.contextualizedTeardownSteps = [];
+
+    if (this.callbacks.teardown) {
+      this.contextualizedTeardownSteps.push( this.callbacks.teardown );
+      delete this.callbacks.teardown;
+    }
+
+    this.teardownSteps.push(this.teardownContainer);
+    this.teardownSteps.push(this.teardownContext);
+    this.teardownSteps.push(this.teardownAJAXListeners);
+    this.teardownSteps.push(this.teardownComponent);
+
+    if (Ember.View && Ember.View.views) {
+      this.teardownSteps.push(this._resetViewRegistry);
+    }
+
+    this.teardownSteps.push(this.teardownTestElements);
+
+    if (this.callbacks.afterTeardown) {
+      this.teardownSteps.push(this.callbacks.afterTeardown);
+      delete this.callbacks.afterTeardown;
+    }
+  },
+
+  setupContainer() {
+    var resolver = getResolver();
+    var items = buildRegistry(resolver);
+
+    this.container = items.container;
+    this.registry = items.registry;
+
+    if (hasEmberVersion(1, 13)) {
+      var thingToRegisterWith = this.registry || this.container;
+      var router = resolver.resolve('router:main');
+      router = router || Ember.Router.extend();
+      thingToRegisterWith.register('router:main', router);
+    }
+  },
+
+  setupContext() {
+    var subjectName = this.subjectName;
+    var container = this.container;
+
+    var factory = function() {
+      return container.lookupFactory(subjectName);
+    };
+
+    this._super({
+      container:  this.container,
+      registry: this.registry,
+      factory:    factory,
+      register() {
+        var target = this.registry || this.container;
+        return target.register.apply(target, arguments);
+      },
+    });
+
+    var context = this.context = getContext();
+
+    if (Ember.setOwner) {
+      Ember.setOwner(context, this.container.owner);
+    }
+
+    if (Ember.inject) {
+      var keys = (Object.keys || Ember.keys)(Ember.inject);
+      keys.forEach(function(typeName) {
+        context.inject[typeName] = function(name, opts) {
+          var alias = (opts && opts.as) || name;
+          Ember.set(context, alias, context.container.lookup(typeName + ':' + name));
+        };
+      });
+    }
+
+    // only setup the injection if we are running against a version
+    // of Ember that has `-view-registry:main` (Ember >= 1.12)
+    if (this.container.lookupFactory('-view-registry:main')) {
+      (this.registry || this.container).injection('component', '_viewRegistry', '-view-registry:main');
+    }
+  },
+
+  setupComponentIntegrationTest: function() {
+    var module = this;
+    var context = this.context;
+
+    this.actionHooks = {};
+
+    context.dispatcher = this.container.lookup('event_dispatcher:main') || Ember.EventDispatcher.create();
+    context.dispatcher.setup({}, '#ember-testing');
+    context.actions = module.actionHooks;
+
+    (this.registry || this.container).register('component:-test-holder', Ember.Component.extend());
+
+    context.render = function(template) {
+      if (!template) {
+        throw new Error("in a component integration test you must pass a template to `render()`");
+      }
+      if (Ember.isArray(template)) {
+        template = template.join('');
+      }
+      if (typeof template === 'string') {
+        template = Ember.Handlebars.compile(template);
+      }
+      module.component = module.container.lookupFactory('component:-test-holder').create({
+        layout: template
+      });
+
+      module.component.set('context' ,context);
+      module.component.set('controller', context);
+
+      Ember.run(function() {
+        module.component.appendTo('#ember-testing');
+      });
+    };
+
+    context.$ = function() {
+      return module.component.$.apply(module.component, arguments);
+    };
+
+    context.set = function(key, value) {
+      var ret = Ember.run(function() {
+        return Ember.set(context, key, value);
+      });
+
+      if (hasEmberVersion(2,0)) {
+        return ret;
+      }
+    };
+
+    context.setProperties = function(hash) {
+      var ret = Ember.run(function() {
+        return Ember.setProperties(context, hash);
+      });
+
+      if (hasEmberVersion(2,0)) {
+        return ret;
+      }
+    };
+
+    context.get = function(key) {
+      return Ember.get(context, key);
+    };
+
+    context.getProperties = function() {
+      var args = Array.prototype.slice.call(arguments);
+      return Ember.getProperties(context, args);
+    };
+
+    context.on = function(actionName, handler) {
+      module.actionHooks[actionName] = handler;
+    };
+
+    context.send = function(actionName) {
+      var hook = module.actionHooks[actionName];
+      if (!hook) {
+        throw new Error("integration testing template received unexpected action " + actionName);
+      }
+      hook.apply(module, Array.prototype.slice.call(arguments, 1));
+    };
+  },
+
+  teardownComponent: function() {
+    var component = this.component;
+    if (component) {
+      Ember.run(function() {
+        component.destroy();
+      });
+    }
+  },
+
+  teardownContainer() {
+    var container = this.container;
+    Ember.run(function() {
+      container.destroy();
+    });
+  },
+
+  // allow arbitrary named factories, like rspec let
+  contextualizeCallbacks() {
+    var callbacks = this.callbacks;
+    var context   = this.context;
+
+    this.cache = this.cache || {};
+    this.cachedCalls = this.cachedCalls || {};
+
+    var keys = (Object.keys || Ember.keys)(callbacks);
+    var keysLength = keys.length;
+
+    if (keysLength) {
+      for (var i = 0; i < keysLength; i++) {
+        this._contextualizeCallback(context, keys[i], context);
+      }
+    }
+  },
+
+  _contextualizeCallback(context, key, callbackContext) {
+    var _this     = this;
+    var callbacks = this.callbacks;
+    var factory   = context.factory;
+
+    context[key] = function(options) {
+      if (_this.cachedCalls[key]) { return _this.cache[key]; }
+
+      var result = callbacks[key].call(callbackContext, options, factory());
+
+      _this.cache[key] = result;
+      _this.cachedCalls[key] = true;
+
+      return result;
+    };
+  },
+
+  _aliasViewRegistry: function() {
+    this._originalGlobalViewRegistry = Ember.View.views;
+    var viewRegistry = this.container.lookup('-view-registry:main');
+
+    if (viewRegistry) {
+      Ember.View.views = viewRegistry;
+    }
+  },
+
+  _resetViewRegistry: function() {
+    Ember.View.views = this._originalGlobalViewRegistry;
+  }
+});

--- a/tests/test-module-for-component-test.js
+++ b/tests/test-module-for-component-test.js
@@ -317,3 +317,305 @@ QUnit.module('moduleForComponent: handles errors thrown during setup', {
 test('it happens', function() {
   ok(true, 'errors are properly thrown/handled');
 });
+
+moduleForComponent('Component Integration Tests', {
+  integration: true,
+  beforeSetup: function() {
+    setResolverRegistry({
+      'template:components/my-component': Ember.Handlebars.compile(
+        '<span>{{name}}</span>'
+      )
+    });
+  }
+});
+
+test('it can render a template', function() {
+  this.render("<span>Hello</span>");
+  equal(this.$('span').text(), 'Hello');
+});
+
+if (hasEmberVersion(1,11)) {
+  test('it can render a link-to', function() {
+    this.render("{{link-to 'Hi' 'index'}}");
+    ok(true, 'it renders without fail');
+  });
+}
+
+test('it complains if you try to use bare render', function() {
+  var self = this;
+  throws(function() {
+    self.render();
+  }, /in a component integration test you must pass a template to `render\(\)`/);
+});
+
+test('it complains if you try to use subject()', function() {
+  var self = this;
+  throws(function() {
+    self.subject();
+  }, /component integration tests do not support `subject\(\)`\./);
+});
+
+test('it can access the full container', function() {
+  this.set('myColor', 'red');
+  this.render('{{my-component name=myColor}}');
+  equal(this.$('span').text(), 'red');
+  this.set('myColor', 'blue');
+  equal(this.$('span').text(), 'blue');
+});
+
+test('it can handle actions', function() {
+  var handlerArg;
+  this.render('<button {{action "didFoo" 42}} />');
+  this.on('didFoo', function(thing) {
+    handlerArg = thing;
+  });
+  this.$('button').click();
+  equal(handlerArg, 42);
+});
+
+test('it accepts precompiled templates', function() {
+  this.render(Ember.Handlebars.compile("<span>Hello</span>"));
+  equal(this.$('span').text(), 'Hello');
+});
+
+test('it supports DOM events', function() {
+  setResolverRegistry({
+    'component:my-component': Ember.Component.extend({
+      value: 0,
+      layout: Ember.Handlebars.compile("<span class='target'>Click to increment!</span><span class='value'>{{value}}</span>"),
+      incrementOnClick: Ember.on('click', function() {
+        this.incrementProperty('value');
+      })
+    })
+  });
+  this.render('{{my-component}}');
+  this.$('.target').click();
+  equal(this.$('.value').text(), '1');
+});
+
+test('it supports updating an input', function() {
+  setResolverRegistry({
+    'component:my-input': Ember.TextField.extend({
+      value: null
+    })
+  });
+  this.render('{{my-input value=value}}');
+  this.$('input').val('1').change();
+  equal(this.get('value'), '1');
+});
+
+test('it supports dom triggered focus events', function() {
+  setResolverRegistry({
+    'component:my-input': Ember.TextField.extend({
+      _onInit: Ember.on('init', function() {
+        this.set('value', 'init');
+      }),
+      focusIn: function() {
+        this.set('value', 'focusin');
+      },
+      focusOut: function() {
+        this.set('value', 'focusout');
+      }
+    })
+  });
+  this.render('{{my-input}}');
+  equal(this.$('input').val(), 'init');
+
+  this.$('input').trigger('focusin');
+  equal(this.$('input').val(), 'focusin');
+
+  this.$('input').trigger('focusout');
+  equal(this.$('input').val(), 'focusout');
+});
+
+moduleForComponent('Component Integration Tests: render during setup', {
+  integration: true,
+  beforeSetup: function() {
+    setResolverRegistry({
+      'component:my-component': Ember.Component.extend({
+        value: 0,
+        layout: Ember.Handlebars.compile("<span class='target'>Click to increment!</span><span class='value'>{{value}}</span>"),
+        incrementOnClick: Ember.on('click', function() {
+          this.incrementProperty('value');
+        })
+      })
+    });
+  },
+  setup: function() {
+    this.render('{{my-component}}');
+  }
+});
+
+test('it has working events', function() {
+  this.$('.target').click();
+  equal(this.$('.value').text(), '1');
+});
+
+moduleForComponent('Component Integration Tests: context', {
+  integration: true,
+  beforeSetup: function() {
+    setResolverRegistry({
+      'component:my-component': Ember.Component.extend({
+        layout: Ember.Handlebars.compile('<span class="foo">{{foo}}</span><span class="bar">{{bar}}</span>')
+      })
+    });
+  }
+});
+
+test('it can set and get properties', function() {
+  var setResult = this.set('foo', 1);
+
+  if (hasEmberVersion(2,0)) {
+    equal(setResult, '1');
+  } else {
+    equal(setResult, undefined);
+  }
+
+  this.render('{{my-component foo=foo}}');
+  equal(this.get('foo'), '1');
+  equal(this.$('.foo').text(), '1');
+});
+
+test('it can setProperties and getProperties', function() {
+  var hash = {
+    foo: 1,
+    bar: 2
+  };
+  var setResult = this.setProperties(hash);
+
+  if (hasEmberVersion(2,0)) {
+    deepEqual(setResult, hash);
+  } else {
+    equal(setResult, undefined);
+  }
+
+  this.render('{{my-component foo=foo bar=bar}}');
+  var properties = this.getProperties('foo', 'bar');
+  equal(properties.foo, '1');
+  equal(properties.bar, '2');
+  equal(this.$('.foo').text(), '1');
+  equal(this.$('.bar').text(), '2');
+});
+
+var origDeprecate;
+moduleForComponent('Component Integration Tests: implicit views are not deprecated', {
+  integration: true,
+  setup: function () {
+    origDeprecate = Ember.deprecate;
+    Ember.deprecate = function(msg, check) {
+      if (!check) {
+        throw new Error("unexpected deprecation: " + msg);
+      }
+    };
+  },
+  teardown: function () {
+    Ember.deprecate = origDeprecate;
+  }
+});
+
+test('the toplevel view is not deprecated', function () {
+  expect(0);
+  this.register('component:my-toplevel', this.container.lookupFactory('view:toplevel'));
+  this.render("{{my-toplevel}}");
+});
+
+
+moduleForComponent('Component Integration Tests: register and inject', {
+  integration: true
+});
+
+test('can register a component', function() {
+  this.register('component:x-foo', Ember.Component.extend({
+    classNames: ['i-am-x-foo']
+  }));
+  this.render("{{x-foo}}");
+  equal(this.$('.i-am-x-foo').length, 1, "found i-am-x-foo");
+});
+
+test('can register a service', function() {
+  this.register('component:x-foo', Ember.Component.extend({
+    unicorn: Ember.inject.service(),
+    layout: Ember.Handlebars.compile('<span class="x-foo">{{unicorn.sparkliness}}</span>')
+  }));
+  this.register('service:unicorn', Ember.Component.extend({
+    sparkliness: 'extreme'
+  }));
+  this.render("{{x-foo}}");
+  equal(this.$('.x-foo').text().trim(), "extreme");
+});
+
+test('can inject a service directly into test context', function() {
+  this.register('component:x-foo', Ember.Component.extend({
+    unicorn: Ember.inject.service(),
+    layout: Ember.Handlebars.compile('<span class="x-foo">{{unicorn.sparkliness}}</span>')
+  }));
+  this.register('service:unicorn', Ember.Component.extend({
+    sparkliness: 'extreme'
+  }));
+  this.inject.service('unicorn');
+  this.render("{{x-foo}}");
+  equal(this.$('.x-foo').text().trim(), "extreme");
+  this.set('unicorn.sparkliness', 'amazing');
+  equal(this.$('.x-foo').text().trim(), "amazing");
+});
+
+test('can inject a service directly into test context, with aliased name', function() {
+  this.register('component:x-foo', Ember.Component.extend({
+    unicorn: Ember.inject.service(),
+    layout: Ember.Handlebars.compile('<span class="x-foo">{{unicorn.sparkliness}}</span>')
+  }));
+  this.register('service:unicorn', Ember.Component.extend({
+    sparkliness: 'extreme'
+  }));
+  this.inject.service('unicorn', { as: 'hornedBeast' });
+  this.render("{{x-foo}}");
+  equal(this.$('.x-foo').text().trim(), "extreme");
+  this.set('hornedBeast.sparkliness', 'amazing');
+  equal(this.$('.x-foo').text().trim(), "amazing");
+});
+
+moduleForComponent('Component Integration Tests: willDestoryElement', {
+  integration: true,
+  beforeSetup: function() {
+    setResolverRegistry({
+      'component:my-component': Ember.Component.extend({
+        willDestroyElement: function() {
+          var stateIndicatesInDOM = (this._state === 'inDOM');
+          var actuallyInDOM = Ember.$.contains(document, this.$()[0]);
+
+          ok((actuallyInDOM === true) && (actuallyInDOM === stateIndicatesInDOM), 'component should still be in the DOM');
+      }
+
+      })
+    });
+  }
+});
+
+test('still in DOM in willDestroyElement', function() {
+    expect(1);
+    this.render("{{my-component}}");
+
+});
+
+if (!hasEmberVersion(2,0)) {
+  moduleForComponent('my-component', 'Component Integration Tests', {
+    integration: 'legacy',
+    beforeSetup: function() {
+      setResolverRegistry({
+        'component:my-component': Ember.Component.extend(),
+        'template:components/my-component': Ember.Handlebars.compile(
+          '<span>{{name}}</span>'
+        )
+      });
+    }
+  });
+
+  test('it can render components semantically equivalent to v0.4.3', function() {
+    this.subject({
+      name: 'Charles XII',
+    });
+    this.render();
+
+    equal(this.$('span').text(), 'Charles XII');
+  });
+}

--- a/tests/test-module-for-integration-test.js
+++ b/tests/test-module-for-integration-test.js
@@ -1,17 +1,16 @@
 import Ember from 'ember';
 import hasEmberVersion from 'ember-test-helpers/has-ember-version';
-import { TestModuleForComponent } from 'ember-test-helpers';
+import { TestModuleForIntegration } from 'ember-test-helpers';
 import test from 'tests/test-support/qunit-test';
 import qunitModuleFor from 'tests/test-support/qunit-module-for';
 import { setResolverRegistry } from 'tests/test-support/resolver';
 
-function moduleForComponent(name, description, callbacks) {
-  var module = new TestModuleForComponent(name, description, callbacks);
+function moduleForIntegration(description, callbacks) {
+  var module = new TestModuleForIntegration(description, callbacks);
   qunitModuleFor(module);
 }
 
-moduleForComponent('Component Integration Tests', {
-  integration: true,
+moduleForIntegration('Component Integration Tests', {
   beforeSetup: function() {
     setResolverRegistry({
       'template:components/my-component': Ember.Handlebars.compile(
@@ -39,14 +38,6 @@ test('it complains if you try to use bare render', function() {
     self.render();
   }, /in a component integration test you must pass a template to `render\(\)`/);
 });
-
-test('it complains if you try to use subject()', function() {
-  var self = this;
-  throws(function() {
-    self.subject();
-  }, /component integration tests do not support `subject\(\)`\./);
-});
-
 
 test('it can access the full container', function() {
   this.set('myColor', 'red');
@@ -121,8 +112,7 @@ test('it supports dom triggered focus events', function() {
   equal(this.$('input').val(), 'focusout');
 });
 
-moduleForComponent('Component Integration Tests: render during setup', {
-  integration: true,
+moduleForIntegration('TestModuleForIntegration | render during setup', {
   beforeSetup: function() {
     setResolverRegistry({
       'component:my-component': Ember.Component.extend({
@@ -144,8 +134,7 @@ test('it has working events', function() {
   equal(this.$('.value').text(), '1');
 });
 
-moduleForComponent('Component Integration Tests: context', {
-  integration: true,
+moduleForIntegration('TestModuleForIntegration | context', {
   beforeSetup: function() {
     setResolverRegistry({
       'component:my-component': Ember.Component.extend({
@@ -191,8 +180,7 @@ test('it can setProperties and getProperties', function() {
 });
 
 var origDeprecate;
-moduleForComponent('Component Integration Tests: implicit views are not deprecated', {
-  integration: true,
+moduleForIntegration('TestModuleForIntegration | implicit views are not deprecated', {
   setup: function () {
     origDeprecate = Ember.deprecate;
     Ember.deprecate = function(msg, check) {
@@ -213,9 +201,7 @@ test('the toplevel view is not deprecated', function () {
 });
 
 
-moduleForComponent('Component Integration Tests: register and inject', {
-  integration: true
-});
+moduleForIntegration('TestModuleForIntegration | register and inject', {});
 
 test('can register a component', function() {
   this.register('component:x-foo', Ember.Component.extend({
@@ -267,8 +253,7 @@ test('can inject a service directly into test context, with aliased name', funct
   equal(this.$('.x-foo').text().trim(), "amazing");
 });
 
-moduleForComponent('Component Integration Tests: willDestoryElement', {
-  integration: true,
+moduleForIntegration('TestModuleForIntegration | willDestoryElement', {
   beforeSetup: function() {
     setResolverRegistry({
       'component:my-component': Ember.Component.extend({
@@ -276,7 +261,7 @@ moduleForComponent('Component Integration Tests: willDestoryElement', {
           var stateIndicatesInDOM = (this._state === 'inDOM');
           var actuallyInDOM = Ember.$.contains(document, this.$()[0]);
 
-          ok((actuallyInDOM === true) && (actuallyInDOM === stateIndicatesInDOM), 'component should still be in the DOM');
+          ok((actuallyInDOM === true) && (stateIndicatesInDOM === true), 'component should still be in the DOM');
       }
 
       })
@@ -289,26 +274,3 @@ test('still in DOM in willDestroyElement', function() {
     this.render("{{my-component}}");
 
 });
-
-if (! hasEmberVersion(2,0)) {
-  moduleForComponent('my-component', 'Component Legacy Integration Tests', {
-    integration: 'legacy',
-    beforeSetup: function() {
-      setResolverRegistry({
-        'component:my-component': Ember.Component.extend(),
-        'template:components/my-component': Ember.Handlebars.compile(
-          '<span>{{name}}</span>'
-        )
-      });
-    }
-  });
-
-  test('it can render components semantically equivalent to v0.4.3', function() {
-    this.subject({
-      name: 'Charles XII',
-    });
-    this.render();
-
-    equal(this.$('span').text(), 'Charles XII');
-  });
-}


### PR DESCRIPTION
This PR moves component integration testing behavior into its own module named (unsurprisingly :smile:) `TestModuleForIntegration`. This new module now depends on `AbstractTestModule` instead of `TestModule` thus removing boilerplate. Additionally, the new module doesn't contain behavior associated with 'legacy' and unit tests. 