### PR TITLE
Update ember-try

### DIFF
--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -101,14 +101,28 @@ module.exports = {
     },
     {
       name: 'ember-data-2.3',
-      dependencies: {
-        "ember": "components/ember#release",
+      bower: {
+        dependencies: {
+          "ember": "components/ember#release",
+        },
+        devDependencies: {
+          // Note that the bower dependency for ember-data is set here to ~2.3,
+          // altough since 2.3 ember-data is a proper addon which is installed
+          // via npm; we are setting the version for the bower dependency here
+          // so we make sure that ember-data 2.3 is used. This can be removed
+          // once there is support for removing dependencies in an ember-try
+          // scenario
+          "ember-data": "~2.3",
+          "ember-cli-shims": "ember-cli/ember-cli-shims#0.1.0"
+        },
+        resolutions: {
+          "ember": "release"
+        }
       },
-      devDependencies: {
-        "ember-data": "~2.3"
-      },
-      resolutions: {
-        "ember": "release"
+      npm: {
+        devDependencies: {
+          "ember-data": "~2.3"
+        }
       }
     }
   ]

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "broccoli-sourcemap-concat": "^0.4.3",
     "ember-cli": "1.13.13",
     "ember-cli-release": "^1.0.0-beta.1",
-    "ember-try": "0.0.8"
+    "ember-try": "https://github.com/kategengler/ember-try#npm-support"
   },
   "dependencies": {
     "klassy": "^0.1.3"


### PR DESCRIPTION
By using the latest version of ember-try, we can change dependencies of
npm packages too. This is useful for the ember-data-2.3 scenario,
because ember-data 2.3 is an addon, which needs to be installed via npm
instead of bower.

---

**TODO**

- [x] wait for kategengler/ember-try#45 to be merged and released in new version
- [x] update `ember-data-2.3` scenario so it uses `ember-data` npm package