### PR TITLE
Fix ember-metal.merge Deprecation

### DIFF
--- a/lib/ember-test-helpers/abstract-test-module.js
+++ b/lib/ember-test-helpers/abstract-test-module.js
@@ -4,6 +4,8 @@ import { setContext, unsetContext } from './test-context';
 
 import Ember from 'ember';
 
+const merge = Ember.assign || Ember.merge;
+
 export default Klass.extend({
   init(name, options) {
     this.name = name;
@@ -95,7 +97,7 @@ export default Klass.extend({
   },
 
   setupContext(options) {
-    var config = Ember.merge({
+    var config = merge({
       dispatcher: null,
       inject: {}
     }, options);


### PR DESCRIPTION
This resolves the warnings due to the http://emberjs.com/deprecations/v2.x/#toc_ember-merge deprecation.