### PR TITLE
Use new path to loader.js

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -20,8 +20,9 @@ module.exports = function(options) {
   // --- Dependencies ---
   var addonVendorTrees = mergeTrees(addonTreesFor('vendor'));
   var loader = new Funnel(addonVendorTrees, {
-    destDir: '/assets',
-    files: ['loader.js']
+    srcDir: 'loader',
+    files: ['loader.js'],
+    destDir: '/assets'
   });
 
   var klassy = new Funnel('node_modules', {


### PR DESCRIPTION
In regards to #150, this should fix the path issue.  However, there seems to be subsequent ember-data related issues.  @rwjblue I bower installed (without saving) ember-data and that addressed those issues only to be left with some `assert.async` related issues.  I figured I'd PR this change and see what happens.  Granted, the tests still won't pass.