### PR TITLE
Ensure prior render is cleared when calling `this.render`.

### DIFF
--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -89,6 +89,7 @@ module.exports = {
     },
     {
       name: 'ember-canary',
+      allowedToFail: true,
       dependencies: {
         "ember": "components/ember#canary"
       },

--- a/lib/ember-test-helpers/test-module-for-component.js
+++ b/lib/ember-test-helpers/test-module-for-component.js
@@ -135,6 +135,9 @@ export default TestModule.extend({
     (this.registry || this.container).register('component:-test-holder', Ember.Component.extend());
 
     context.render = function(template) {
+      // in case `this.render` is called twice, make sure to teardown the first invocation
+      module.teardownComponent();
+
       if (!template) {
         throw new Error("in a component integration test you must pass a template to `render()`");
       }
@@ -223,9 +226,8 @@ export default TestModule.extend({
   teardownComponent: function() {
     var component = this.component;
     if (component) {
-      Ember.run(function() {
-        component.destroy();
-      });
+      Ember.run(component, 'destroy');
+      this.component = null;
     }
   }
 });

--- a/tests/test-module-for-component-test.js
+++ b/tests/test-module-for-component-test.js
@@ -595,6 +595,12 @@ test('still in DOM in willDestroyElement', function() {
     this.render("{{my-component}}");
 });
 
+test('is destroyed when rendered twice', function() {
+  expect(2);
+  this.render("{{my-component}}");
+  this.render("{{my-component}}");
+});
+
 moduleForComponent('Component Integration Tests: force willDestroyElement via clearRender', {
   integration: true,
   beforeSetup: function() {


### PR DESCRIPTION
Previously, calling `this.render` twice within the same test (without calling `this.clearRender()` in between) would cause any components created in the first render to never be destroyed (and therefore they cannot cleanup any listeners they created).

This change essentially ensures that we call `clearRender` before each `this.render` invocation so that if a component had been previously instantiated it is cleared and reset.

Fixes #111.