### PR TITLE
Remove usage of `context` in `moduleForComponent`.

### DIFF
--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -64,40 +64,126 @@ module.exports = {
       }
     },
     {
-      name: 'ember-release',
+      name: 'ember-2.3',
       dependencies: {
-        "ember": "components/ember#release"
+        "ember": "~2.3.0"
       },
       devDependencies: {
-        "ember-data": "~2.2.0"
+        "ember-data": "~2.3.0"
+      }
+    },
+    {
+      name: 'ember-2.4',
+      bower: {
+        dependencies: {
+          "ember": "~2.4.0"
+        },
+        devDependencies: {
+          "ember-cli-shims": "ember-cli/ember-cli-shims#0.1.0"
+        },
+        resolutions: {
+          "ember": "~2.4.0"
+        }
       },
-      resolutions: {
-        "ember": "release"
+      npm: {
+        devDependencies: {
+          "ember-data": "~2.4"
+        }
+      }
+    },
+    {
+      name: 'ember-2.5',
+      bower: {
+        dependencies: {
+          "ember": "~2.5.0"
+        },
+        devDependencies: {
+          "ember-cli-shims": "ember-cli/ember-cli-shims#0.1.0"
+        },
+        resolutions: {
+          "ember": "~2.5.0"
+        }
+      },
+      npm: {
+        devDependencies: {
+          "ember-data": "~2.5"
+        }
+      }
+    },
+    {
+      name: 'ember-2.6',
+      bower: {
+        dependencies: {
+          "ember": "~2.6.0-beta.1"
+        },
+        devDependencies: {
+          "ember-cli-shims": "ember-cli/ember-cli-shims#0.1.0"
+        },
+        resolutions: {
+          "ember": "~2.6.0-beta.1"
+        }
+      },
+      npm: {
+        devDependencies: {
+          "ember-data": "^2.5.0"
+        }
+      }
+    },
+    {
+      name: 'ember-release',
+      bower: {
+        dependencies: {
+          "ember": "components/ember#release"
+        },
+        devDependencies: {
+          "ember-cli-shims": "ember-cli/ember-cli-shims#0.1.0"
+        },
+        resolutions: {
+          "ember": "release"
+        }
+      },
+      npm: {
+        devDependencies: {
+          "ember-data": "^2.5.0"
+        }
       }
     },
     {
       name: 'ember-beta',
-      dependencies: {
-        "ember": "components/ember#beta"
+      bower: {
+        dependencies: {
+          "ember": "components/ember#beta"
+        },
+        devDependencies: {
+          "ember-cli-shims": "ember-cli/ember-cli-shims#0.1.0"
+        },
+        resolutions: {
+          "ember": "beta"
+        }
       },
-      devDependencies: {
-        "ember-data": "~2.2.0"
-      },
-      resolutions: {
-        "ember": "beta"
+      npm: {
+        devDependencies: {
+          "ember-data": "^2.5.0"
+        }
       }
     },
     {
       name: 'ember-canary',
-      allowedToFail: true,
-      dependencies: {
-        "ember": "components/ember#canary"
+      bower: {
+        dependencies: {
+          "ember": "components/ember#canary"
+        },
+        devDependencies: {
+          "ember-cli-shims": "ember-cli/ember-cli-shims#0.1.0"
+        },
+        resolutions: {
+          "ember": "canary"
+        }
       },
-      devDependencies: {
-        "ember-data": "~2.2.0"
-      },
-      resolutions: {
-        "ember": "canary"
+      npm: {
+        devDependencies: {
+          "ember-data": "^2.5.0"
+        }
       }
     },
     {

--- a/lib/ember-test-helpers/test-module-for-component.js
+++ b/lib/ember-test-helpers/test-module-for-component.js
@@ -5,6 +5,13 @@ import hasEmberVersion from './has-ember-version';
 
 const BASE_COMPONENT_KEYS = (Object.keys || Ember.keys)(Ember.Component.create());
 
+let ACTION_KEY;
+if (hasEmberVersion(2,0)) {
+  ACTION_KEY = 'actions';
+} else {
+  ACTION_KEY = '_actions';
+}
+
 export default TestModule.extend({
   isComponentTestModule: true,
 
@@ -129,7 +136,8 @@ export default TestModule.extend({
     var context = this.context;
 
     var actions = this.actionHooks = {};
-    var setContext = this._setBuffer = { actions };
+    var setContext = this._setBuffer = { };
+    setContext[ACTION_KEY] = {};
 
     context.dispatcher = this.container.lookup('event_dispatcher:main') || Ember.EventDispatcher.create();
     context.dispatcher.setup({}, '#ember-testing');
@@ -194,12 +202,12 @@ export default TestModule.extend({
     };
 
     context.on = function(actionName, handler) {
-      setContext.actions = setContext.actions || {};
-      setContext.actions[actionName] = handler;
+      setContext[ACTION_KEY][actionName] = handler;
     };
 
     context.clearRender = function() {
-      setContext = this._setBuffer = { actions };
+      setContext = this._setBuffer = { };
+      setContext[ACTION_KEY] = actions;
 
       for (var key in module.component) {
         if (BASE_COMPONENT_KEYS.indexOf(key) === -1) {

--- a/lib/ember-test-helpers/test-module-for-component.js
+++ b/lib/ember-test-helpers/test-module-for-component.js
@@ -3,6 +3,8 @@ import Ember from 'ember';
 import { getResolver } from './test-resolver';
 import hasEmberVersion from './has-ember-version';
 
+const BASE_COMPONENT_KEYS = (Object.keys || Ember.keys)(Ember.Component.create());
+
 export default TestModule.extend({
   isComponentTestModule: true,
 
@@ -126,17 +128,19 @@ export default TestModule.extend({
     var module = this;
     var context = this.context;
 
-    this.actionHooks = {};
+    var actions = this.actionHooks = {};
+    var setContext = this._setBuffer = { actions };
 
     context.dispatcher = this.container.lookup('event_dispatcher:main') || Ember.EventDispatcher.create();
     context.dispatcher.setup({}, '#ember-testing');
-    context.actions = module.actionHooks;
 
     (this.registry || this.container).register('component:-test-holder', Ember.Component.extend());
 
     context.render = function(template) {
       // in case `this.render` is called twice, make sure to teardown the first invocation
-      module.teardownComponent();
+      if (module.component) {
+        context.clearRender();
+      }
 
       if (!template) {
         throw new Error("in a component integration test you must pass a template to `render()`");
@@ -147,12 +151,9 @@ export default TestModule.extend({
       if (typeof template === 'string') {
         template = Ember.Handlebars.compile(template);
       }
-      module.component = module.container.lookupFactory('component:-test-holder').create({
-        layout: template
-      });
 
-      module.component.set('context' ,context);
-      module.component.set('controller', context);
+      var Component = module.container.lookupFactory('component:-test-holder').extend(setContext);
+      setContext = module._setBuffer = module.component = Component.create({ layout: template });
 
       Ember.run(function() {
         module.component.appendTo('#ember-testing');
@@ -165,7 +166,7 @@ export default TestModule.extend({
 
     context.set = function(key, value) {
       var ret = Ember.run(function() {
-        return Ember.set(context, key, value);
+        return Ember.set(setContext, key, value);
       });
 
       if (hasEmberVersion(2,0)) {
@@ -175,7 +176,7 @@ export default TestModule.extend({
 
     context.setProperties = function(hash) {
       var ret = Ember.run(function() {
-        return Ember.setProperties(context, hash);
+        return Ember.setProperties(setContext, hash);
       });
 
       if (hasEmberVersion(2,0)) {
@@ -184,29 +185,47 @@ export default TestModule.extend({
     };
 
     context.get = function(key) {
-      return Ember.get(context, key);
+      return Ember.get(setContext, key);
     };
 
     context.getProperties = function() {
       var args = Array.prototype.slice.call(arguments);
-      return Ember.getProperties(context, args);
+      return Ember.getProperties(setContext, args);
     };
 
     context.on = function(actionName, handler) {
-      module.actionHooks[actionName] = handler;
-    };
-
-    context.send = function(actionName) {
-      var hook = module.actionHooks[actionName];
-      if (!hook) {
-        throw new Error("integration testing template received unexpected action " + actionName);
-      }
-      hook.apply(module, Array.prototype.slice.call(arguments, 1));
+      setContext.actions = setContext.actions || {};
+      setContext.actions[actionName] = handler;
     };
 
     context.clearRender = function() {
+      setContext = this._setBuffer = { actions };
+
+      for (var key in module.component) {
+        if (BASE_COMPONENT_KEYS.indexOf(key) === -1) {
+          setContext[key] = Ember.get(module.component, key);
+        }
+      }
       module.teardownComponent();
     };
+  },
+
+  setupInject: function() {
+    var module = this;
+
+    if (Ember.inject) {
+      var keys = (Object.keys || Ember.keys)(Ember.inject);
+
+      keys.forEach(function(typeName) {
+        module.context.inject[typeName] = function(name, opts) {
+          var alias = (opts && opts.as) || name;
+          var instance = module.container.lookup(typeName + ':' + name);
+
+          Ember.set(module.context, alias, instance);
+          Ember.set(module._setBuffer, alias, instance);
+        };
+      });
+    }
   },
 
   setupContext: function() {

--- a/lib/ember-test-helpers/test-module.js
+++ b/lib/ember-test-helpers/test-module.js
@@ -128,12 +128,20 @@ export default AbstractTestModule.extend({
       Ember.setOwner(context, this.container.owner);
     }
 
+    this.setupInject();
+  },
+
+  setupInject: function() {
+    var module = this;
+    var context = this.context;
+
     if (Ember.inject) {
       var keys = (Object.keys || Ember.keys)(Ember.inject);
+
       keys.forEach(function(typeName) {
         context.inject[typeName] = function(name, opts) {
           var alias = (opts && opts.as) || name;
-          Ember.set(context, alias, context.container.lookup(typeName + ':' + name));
+          Ember.set(context, alias, module.container.lookup(typeName + ':' + name));
         };
       });
     }

--- a/lib/ember-test-helpers/wait.js
+++ b/lib/ember-test-helpers/wait.js
@@ -27,20 +27,21 @@ export function _setupAJAXHooks() {
   jQuery(document).on('ajaxComplete', decrementAjaxPendingRequests);
 }
 
-var checkWaiters;
+var _internalCheckWaiters;
+if (Ember.__loader.registry['ember-testing/test/waiters']) {
+  _internalCheckWaiters = Ember.__loader.require('ember-testing/test/waiters').checkWaiters;
+}
 
-if (Ember.Test.waiters) {
-  checkWaiters = () => {
+function checkWaiters() {
+  if (_internalCheckWaiters) {
+    return _internalCheckWaiters();
+  } else if (Ember.Test.waiters) {
     if (Ember.Test.waiters.any(([context, callback]) => !callback.call(context) )) {
       return true;
     }
+  }
 
-    return false;
-  };
-} else if (Ember.__loader.registry['ember-testing/test/waiters']) {
-  checkWaiters = Ember.__loader.require('ember-testing/test/waiters').checkWaiters;
-} else {
-  checkWaiters = () => false;
+  return false;
 }
 
 export default function wait(_options) {

--- a/lib/ember-test-helpers/wait.js
+++ b/lib/ember-test-helpers/wait.js
@@ -27,6 +27,22 @@ export function _setupAJAXHooks() {
   jQuery(document).on('ajaxComplete', decrementAjaxPendingRequests);
 }
 
+var checkWaiters;
+
+if (Ember.Test.waiters) {
+  checkWaiters = () => {
+    if (Ember.Test.waiters.any(([context, callback]) => !callback.call(context) )) {
+      return true;
+    }
+
+    return false;
+  };
+} else if (Ember.__loader.registry['ember-testing/test/waiters']) {
+  checkWaiters = Ember.__loader.require('ember-testing/test/waiters').checkWaiters;
+} else {
+  checkWaiters = () => false;
+}
+
 export default function wait(_options) {
   var options = _options || {};
   var waitForTimers = options.hasOwnProperty('waitForTimers') ? options.waitForTimers : true;
@@ -43,11 +59,10 @@ export default function wait(_options) {
         return;
       }
 
-      if (waitForWaiters && Ember.Test.waiters && Ember.Test.waiters.any(([context, callback]) => {
-            return !callback.call(context);
-          })) {
+      if (waitForWaiters && checkWaiters()) {
         return;
       }
+
 
       // Stop polling
       self.clearInterval(watcher);

--- a/tests/test-module-for-component-test.js
+++ b/tests/test-module-for-component-test.js
@@ -253,6 +253,12 @@ if (hasEmberVersion(1,13)) {
     this.on('colorChange', function(arg) { equal(arg, 'foo'); });
     this.render(Ember.Handlebars.compile("{{changing-color change=(action 'colorChange')}}"));
   });
+
+  test('handles a closure actions when set on the test context', function() {
+    expect(1);
+    this.set('colorChange', function(arg) { equal(arg, 'foo'); });
+    this.render(Ember.Handlebars.compile("{{changing-color change=(action colorChange)}}"));
+  });
 }
 
 var testModule;
@@ -497,6 +503,70 @@ test('it can setProperties and getProperties', function() {
   equal(this.$('.bar').text(), '2');
 });
 
+test('two way bound arguments are updated', function() {
+  var instance;
+  setResolverRegistry({
+    'component:my-component': Ember.Component.extend({
+      init: function() {
+        this._super();
+        instance = this;
+      },
+      didInsertElement: function() {
+        Ember.run.schedule('afterRender', () => {
+          this.set('foo', 'updated!');
+        });
+      }
+    })
+  });
+
+  this.set('foo', 'original');
+  this.render('{{my-component foo=foo}}');
+
+  equal(instance.get('foo'), 'updated!');
+  equal(this.get('foo'), 'updated!');
+});
+
+test('two way bound arguments are available after clearRender is called', function() {
+  setResolverRegistry({
+    'component:my-component': Ember.Component.extend({
+      didInsertElement: function() {
+        Ember.run.schedule('afterRender', () => {
+          this.set('foo', 'updated!');
+          this.set('bar', 'updated bar!');
+        });
+      }
+    })
+  });
+
+  this.set('foo', 'original');
+  this.render('{{my-component foo=foo bar=bar}}');
+  this.clearRender();
+
+  equal(this.get('foo'), 'updated!');
+  equal(this.get('bar'), 'updated bar!');
+});
+
+test('rendering after calling clearRender', function() {
+  setResolverRegistry({
+    'component:my-component': Ember.Component.extend({
+      didInsertElement: function() {
+        Ember.run.schedule('afterRender', () => {
+          let currentFoo = this.get('foo') || '';
+          this.set('foo', currentFoo + 'more foo ');
+        });
+      }
+    })
+  });
+
+  this.render('{{my-component foo=foo}}');
+  equal(this.get('foo'), 'more foo ', 'precond - renders initially');
+  this.clearRender();
+
+  this.render('{{my-component foo=foo}}');
+  equal(this.get('foo'), 'more foo more foo ', 'uses the previously rendered value');
+  this.clearRender();
+});
+
 var origDeprecate;
 moduleForComponent('Component Integration Tests: implicit views are not deprecated', {
   integration: true,
@@ -549,12 +619,16 @@ test('can inject a service directly into test context', function() {
     unicorn: Ember.inject.service(),
     layout: Ember.Handlebars.compile('<span class="x-foo">{{unicorn.sparkliness}}</span>')
   }));
+
   this.register('service:unicorn', Ember.Component.extend({
     sparkliness: 'extreme'
   }));
+
   this.inject.service('unicorn');
   this.render("{{x-foo}}");
+
   equal(this.$('.x-foo').text().trim(), "extreme");
+
   this.set('unicorn.sparkliness', 'amazing');
   equal(this.$('.x-foo').text().trim(), "amazing");
 });


### PR DESCRIPTION
Setting `context` or `controller` on an `Ember.Component` was absolutely not supposed to work (ever), but this library worked around that to serve its own needs when `Ember.View` was deprecated and removed.

This PR makes `moduleForComponent` work properly against canary (soon to be 2.7.0), by avoiding this archaic concept and simply tracking the things `set` on the test context manually.