### PR TITLE
Fix regression related to DOM structure.

### DIFF
--- a/lib/ember-test-helpers/-legacy-overrides.js
+++ b/lib/ember-test-helpers/-legacy-overrides.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 
 import hasEmberVersion from './has-ember-version';
 
-export function preoutletRefactorSetupIntegrationForComponent() {
+export function preGlimmerSetupIntegrationForComponent() {
   var module = this;
   var context = this.context;
 

--- a/lib/ember-test-helpers/test-module-for-component.js
+++ b/lib/ember-test-helpers/test-module-for-component.js
@@ -168,6 +168,11 @@ export default TestModule.extend({
               }
             });
           });
+
+          // ensure the element is based on the wrapping toplevel view
+          // Ember still wraps the main application template with a
+          // normal tagged view
+          element = Ember.$('#ember-testing > .ember-view');
         };
 
         context.$ = function(selector) {

--- a/lib/ember-test-helpers/test-module-for-component.js
+++ b/lib/ember-test-helpers/test-module-for-component.js
@@ -2,7 +2,7 @@ import TestModule from './test-module';
 import Ember from 'ember';
 import { getResolver } from './test-resolver';
 import hasEmberVersion from './has-ember-version';
-import { preoutletRefactorSetupIntegrationForComponent } from './-legacy-overrides';
+import { preGlimmerSetupIntegrationForComponent } from './-legacy-overrides';
 
 let ACTION_KEY;
 if (hasEmberVersion(2,0)) {
@@ -131,8 +131,8 @@ export default TestModule.extend({
   },
 
   setupComponentIntegrationTest: (function() {
-    if (!hasEmberVersion(1,11)) {
-      return preoutletRefactorSetupIntegrationForComponent;
+    if (!hasEmberVersion(1,13)) {
+      return preGlimmerSetupIntegrationForComponent;
     } else {
       return function() {
         var module = this;
@@ -165,7 +165,9 @@ export default TestModule.extend({
               render: {
                 controller: module.context,
                 template
-              }
+              },
+
+              outlets: { }
             });
           });
 

--- a/tests/test-module-for-component-test.js
+++ b/tests/test-module-for-component-test.js
@@ -698,6 +698,33 @@ test('still in DOM in willDestroyElement', function() {
   ok(willDestroyCalled, 'can add assertions after willDestroyElement is called');
 });
 
+
+moduleForComponent('Component Integration Tests: DOM', {
+  integration: true,
+  beforeSetup: function() {
+  }
+});
+
+test('it can set and get properties', function() {
+  let instance;
+
+  setResolverRegistry({
+    'component:my-component': Ember.Component.extend({
+      init() {
+        this._super(...arguments);
+        instance = this;
+      },
+      layout: Ember.Handlebars.compile('<span class="foo"></span>')
+    })
+  });
+  this.render('{{my-component}}');
+
+  let testElement = this.$()[0];
+  let instanceElement = instance.element;
+
+  ok(testElement.children[0] === instanceElement, 'the first child of the test harness is whatever is rendered');
+});
+
 if (!hasEmberVersion(2,0)) {
   moduleForComponent('my-component', 'Component Integration Tests', {
     integration: 'legacy',


### PR DESCRIPTION
Ensures that `this.$()` from within a test represents the same structure as prior versions.

Ultimately, I would prefer for `this.$()` to refer to the inner HTML (basically what is rendered by the template provided to `this.render`), but changing the underlying structure is definitely not good without proper messaging (and likely major version bump).

Fixes #159.