### PR TITLE
More alpha work.

### DIFF
--- a/lib/ember-test-helpers/test-module-for-component.js
+++ b/lib/ember-test-helpers/test-module-for-component.js
@@ -11,6 +11,8 @@ if (hasEmberVersion(2,0)) {
   ACTION_KEY = '_actions';
 }
 
+const { getOwner } = Ember;
+
 export default TestModule.extend({
   isComponentTestModule: true,
 
@@ -144,10 +146,35 @@ export default TestModule.extend({
 
         var hasRendered = false;
         var OutletView = module.container.lookupFactory('view:-outlet');
+        var OutletTemplate = module.container.lookup('template:-outlet');
         var toplevelView = module.component = OutletView.create();
+        var hasOutletTemplate = !!OutletTemplate;
+        var outletState = {
+          render: {
+            owner: getOwner ? getOwner(module.container) : undefined,
+            into: undefined,
+            outlet: 'main',
+            name: 'application',
+            controller: module.context,
+            ViewClass: undefined,
+            template: OutletTemplate
+          },
+
+          outlets: { }
+        };
 
         var element = document.getElementById('ember-testing');
         var templateId = 0;
+
+        if (hasOutletTemplate) {
+          Ember.run(() => {
+            toplevelView.setOutletState(outletState);
+          });
+
+          Ember.run(module.component, 'appendTo', '#ember-testing');
+          hasRendered = true;
+        }
+
         context.render = function(template) {
           if (!template) {
             throw new Error("in a component integration test you must pass a template to `render()`");
@@ -161,20 +188,27 @@ export default TestModule.extend({
 
           var templateFullName = 'template:-undertest-' + (++templateId);
           this.registry.register(templateFullName, template);
-          Ember.run(() => {
-            toplevelView.setOutletState({
-              render: {
-                owner: this.owner,
-                into: undefined,
-                outlet: 'main',
-                name: 'application',
-                controller: module.context,
-                ViewClass: undefined,
-                template: this.container.lookup(templateFullName)
-              },
+          var stateToRender = {
+            owner: getOwner ? getOwner(module.container) : undefined,
+            into: undefined,
+            outlet: 'main',
+            name: 'index',
+            controller: module.context,
+            ViewClass: undefined,
+            template: module.container.lookup(templateFullName),
+            outlets: { }
+          };
 
-              outlets: { }
-            });
+          if (hasOutletTemplate) {
+            stateToRender.name = 'index';
+            outletState.outlets.main = { render: stateToRender, outlets: {} };
+          } else {
+            stateToRender.name = 'application';
+            outletState = { render: stateToRender, outlets: {} };
+          }
+
+          Ember.run(() => {
+            toplevelView.setOutletState(outletState);
           });
 
           if (!hasRendered) {

--- a/lib/ember-test-helpers/test-module-for-integration.js
+++ b/lib/ember-test-helpers/test-module-for-integration.js
@@ -13,6 +13,8 @@ if (hasEmberVersion(2,0)) {
   ACTION_KEY = '_actions';
 }
 
+const { getOwner } = Ember;
+
 export default AbstractTestModule.extend({
   initSetupSteps() {
     this.setupSteps = [];
@@ -109,7 +111,9 @@ export default AbstractTestModule.extend({
       keys.forEach(function(typeName) {
         context.inject[typeName] = function(name, opts) {
           var alias = (opts && opts.as) || name;
-          Ember.set(context, alias, context.container.lookup(typeName + ':' + name));
+          Ember.run(function() {
+            Ember.set(context, alias, context.container.lookup(typeName + ':' + name));
+          });
         };
       });
     }
@@ -133,12 +137,36 @@ export default AbstractTestModule.extend({
         context.dispatcher = this.container.lookup('event_dispatcher:main') || Ember.EventDispatcher.create();
         context.dispatcher.setup({}, '#ember-testing');
 
+        var hasRendered = false;
         var OutletView = module.container.lookupFactory('view:-outlet');
+        var OutletTemplate = module.container.lookup('template:-outlet');
         var toplevelView = module.component = OutletView.create();
-        toplevelView.setOutletState({ render: { }, outlets: { }});
+        var hasOutletTemplate = !!OutletTemplate;
+        var outletState = {
+          render: {
+            owner: getOwner ? getOwner(module.container) : undefined,
+            into: undefined,
+            outlet: 'main',
+            name: 'application',
+            controller: module.context,
+            ViewClass: undefined,
+            template: OutletTemplate
+          },
+
+          outlets: { }
+        };
 
         var element = document.getElementById('ember-testing');
-        Ember.run(module.component, 'appendTo', '#ember-testing');
+        var templateId = 0;
+
+        if (hasOutletTemplate) {
+          Ember.run(() => {
+            toplevelView.setOutletState(outletState);
+          });
+
+          Ember.run(module.component, 'appendTo', '#ember-testing');
+          hasRendered = true;
+        }
 
         context.render = function(template) {
           if (!template) {
@@ -151,16 +179,35 @@ export default AbstractTestModule.extend({
             template = Ember.Handlebars.compile(template);
           }
 
-          Ember.run(function() {
-            toplevelView.setOutletState({
-              render: {
-                controller: module.context,
-                template
-              },
+          var templateFullName = 'template:-undertest-' + (++templateId);
+          this.registry.register(templateFullName, template);
+          var stateToRender = {
+            owner: getOwner ? getOwner(module.container) : undefined,
+            into: undefined,
+            outlet: 'main',
+            name: 'index',
+            controller: module.context,
+            ViewClass: undefined,
+            template: module.container.lookup(templateFullName),
+            outlets: { }
+          };
 
-              outlets: { }
-            });
+          if (hasOutletTemplate) {
+            stateToRender.name = 'index';
+            outletState.outlets.main = { render: stateToRender, outlets: {} };
+          } else {
+            stateToRender.name = 'application';
+            outletState = { render: stateToRender, outlets: {} };
+          }
+
+          Ember.run(() => {
+            toplevelView.setOutletState(outletState);
           });
+
+          if (!hasRendered) {
+            Ember.run(module.component, 'appendTo', '#ember-testing');
+            hasRendered = true;
+          }
 
           // ensure the element is based on the wrapping toplevel view
           // Ember still wraps the main application template with a
@@ -219,8 +266,13 @@ export default AbstractTestModule.extend({
           Ember.run(function() {
             toplevelView.setOutletState({
               render: {
+                owner: module.container,
+                into: undefined,
+                outlet: 'main',
+                name: 'application',
                 controller: module.context,
-                randomKey: 'empty'
+                ViewClass: undefined,
+                template: undefined
               },
               outlets: {}
             });

--- a/lib/ember-test-helpers/test-module.js
+++ b/lib/ember-test-helpers/test-module.js
@@ -141,7 +141,9 @@ export default AbstractTestModule.extend({
       keys.forEach(function(typeName) {
         context.inject[typeName] = function(name, opts) {
           var alias = (opts && opts.as) || name;
-          Ember.set(context, alias, module.container.lookup(typeName + ':' + name));
+          Ember.run(function() {
+            Ember.set(context, alias, module.container.lookup(typeName + ':' + name));
+          });
         };
       });
     }

--- a/tests/test-module-for-component-test.js
+++ b/tests/test-module-for-component-test.js
@@ -7,8 +7,15 @@ import { setResolverRegistry } from 'tests/test-support/resolver';
 
 var $ = Ember.$;
 
+var Service = Ember.Service || Ember.Object;
+
 function moduleForComponent(name, description, callbacks) {
   var module = new TestModuleForComponent(name, description, callbacks);
+  if (module.isIntegration) {
+    module.name += ' [INTEGRATION]';
+  } else {
+    module.name += ' [UNIT]';
+  }
   qunitModuleFor(module);
 }
 
@@ -567,29 +574,6 @@ test('rendering after calling clearRender', function() {
   this.clearRender();
 });
 
-var origDeprecate;
-moduleForComponent('Component Integration Tests: implicit views are not deprecated', {
-  integration: true,
-  setup: function () {
-    origDeprecate = Ember.deprecate;
-    Ember.deprecate = function(msg, check) {
-      if (!check) {
-        throw new Error("unexpected deprecation: " + msg);
-      }
-    };
-  },
-  teardown: function () {
-    Ember.deprecate = origDeprecate;
-  }
-});
-
-test('the toplevel view is not deprecated', function () {
-  expect(0);
-  this.register('component:my-toplevel', this.container.lookupFactory('view:toplevel'));
-  this.render("{{my-toplevel}}");
-});
-
-
 moduleForComponent('Component Integration Tests: register and inject', {
   integration: true
 });
@@ -607,7 +591,7 @@ test('can register a service', function() {
     unicorn: Ember.inject.service(),
     layout: Ember.Handlebars.compile('<span class="x-foo">{{unicorn.sparkliness}}</span>')
   }));
-  this.register('service:unicorn', Ember.Component.extend({
+  this.register('service:unicorn', Service.extend({
     sparkliness: 'extreme'
   }));
   this.render("{{x-foo}}");
@@ -620,7 +604,7 @@ test('can inject a service directly into test context', function() {
     layout: Ember.Handlebars.compile('<span class="x-foo">{{unicorn.sparkliness}}</span>')
   }));
 
-  this.register('service:unicorn', Ember.Component.extend({
+  this.register('service:unicorn', Service.extend({
     sparkliness: 'extreme'
   }));
 
@@ -638,7 +622,7 @@ test('can inject a service directly into test context, with aliased name', funct
     unicorn: Ember.inject.service(),
     layout: Ember.Handlebars.compile('<span class="x-foo">{{unicorn.sparkliness}}</span>')
   }));
-  this.register('service:unicorn', Ember.Component.extend({
+  this.register('service:unicorn', Service.extend({
     sparkliness: 'extreme'
   }));
   this.inject.service('unicorn', { as: 'hornedBeast' });

--- a/tests/test-module-for-integration-test.js
+++ b/tests/test-module-for-integration-test.js
@@ -179,28 +179,6 @@ test('it can setProperties and getProperties', function() {
   equal(this.$('.bar').text(), '2');
 });
 
-var origDeprecate;
-moduleForIntegration('TestModuleForIntegration | implicit views are not deprecated', {
-  setup: function () {
-    origDeprecate = Ember.deprecate;
-    Ember.deprecate = function(msg, check) {
-      if (!check) {
-        throw new Error("unexpected deprecation: " + msg);
-      }
-    };
-  },
-  teardown: function () {
-    Ember.deprecate = origDeprecate;
-  }
-});
-
-test('the toplevel view is not deprecated', function () {
-  expect(0);
-  this.register('component:my-toplevel', this.container.lookupFactory('view:toplevel'));
-  this.render("{{my-toplevel}}");
-});
-
-
 moduleForIntegration('TestModuleForIntegration | register and inject', {});
 
 test('can register a component', function() {

--- a/tests/test-module-for-integration-test.js
+++ b/tests/test-module-for-integration-test.js
@@ -5,6 +5,8 @@ import test from 'tests/test-support/qunit-test';
 import qunitModuleFor from 'tests/test-support/qunit-module-for';
 import { setResolverRegistry } from 'tests/test-support/resolver';
 
+const Service = Ember.Service || Ember.Object;
+
 function moduleForIntegration(description, callbacks) {
   var module = new TestModuleForIntegration(description, callbacks);
   qunitModuleFor(module);
@@ -194,7 +196,7 @@ test('can register a service', function() {
     unicorn: Ember.inject.service(),
     layout: Ember.Handlebars.compile('<span class="x-foo">{{unicorn.sparkliness}}</span>')
   }));
-  this.register('service:unicorn', Ember.Component.extend({
+  this.register('service:unicorn', Service.extend({
     sparkliness: 'extreme'
   }));
   this.render("{{x-foo}}");
@@ -206,7 +208,7 @@ test('can inject a service directly into test context', function() {
     unicorn: Ember.inject.service(),
     layout: Ember.Handlebars.compile('<span class="x-foo">{{unicorn.sparkliness}}</span>')
   }));
-  this.register('service:unicorn', Ember.Component.extend({
+  this.register('service:unicorn', Service.extend({
     sparkliness: 'extreme'
   }));
   this.inject.service('unicorn');
@@ -221,7 +223,7 @@ test('can inject a service directly into test context, with aliased name', funct
     unicorn: Ember.inject.service(),
     layout: Ember.Handlebars.compile('<span class="x-foo">{{unicorn.sparkliness}}</span>')
   }));
-  this.register('service:unicorn', Ember.Component.extend({
+  this.register('service:unicorn', Service.extend({
     sparkliness: 'extreme'
   }));
   this.inject.service('unicorn', { as: 'hornedBeast' });

--- a/tests/test-support/resolver.js
+++ b/tests/test-support/resolver.js
@@ -17,7 +17,7 @@ var resolver = Resolver.create({registry: {}, namespace: {}});
 setResolver(resolver);
 
 export function setResolverRegistry(registry) {
-  resolver.set('registry', registry);
+  Ember.run(resolver, 'set', 'registry', registry);
 }
 
 export default {


### PR DESCRIPTION
This fixes `clearRender` within an integration test (and should make `ember g component foo-bar && ember test` work out of the box).