### PR TITLE
Introduce resolver option to test module

### DIFF
--- a/lib/ember-test-helpers/test-module-for-component.js
+++ b/lib/ember-test-helpers/test-module-for-component.js
@@ -1,6 +1,5 @@
 import TestModule from './test-module';
 import Ember from 'ember';
-import { getResolver } from './test-resolver';
 import hasEmberVersion from './has-ember-version';
 import { preGlimmerSetupIntegrationForComponent } from './-legacy-overrides';
 
@@ -84,7 +83,7 @@ export default TestModule.extend({
 
   setupComponentUnitTest: function() {
     var _this = this;
-    var resolver = getResolver();
+    var resolver = this.resolver;
     var context = this.context;
 
     var layoutName = 'template:components/' + this.componentName;

--- a/lib/ember-test-helpers/test-module-for-integration.js
+++ b/lib/ember-test-helpers/test-module-for-integration.js
@@ -14,6 +14,11 @@ if (hasEmberVersion(2,0)) {
 }
 
 export default AbstractTestModule.extend({
+  init() {
+    this._super(...arguments);
+    this.resolver = this.callbacks.resolver || getResolver();
+  },
+
   initSetupSteps() {
     this.setupSteps = [];
     this.contextualizedSetupSteps = [];
@@ -66,7 +71,7 @@ export default AbstractTestModule.extend({
   },
 
   setupContainer() {
-    var resolver = getResolver();
+    var resolver = this.resolver;
     var items = buildRegistry(resolver);
 
     this.container = items.container;

--- a/lib/ember-test-helpers/test-module.js
+++ b/lib/ember-test-helpers/test-module.js
@@ -17,6 +17,7 @@ export default AbstractTestModule.extend({
     this.description = description || subjectName;
     this.name = description || subjectName;
     this.callbacks = callbacks || {};
+    this.resolver = this.callbacks.resolver || getResolver();
 
     if (this.callbacks.integration && this.callbacks.needs) {
       throw new Error("cannot declare 'integration: true' and 'needs' in the same module");
@@ -234,7 +235,7 @@ export default AbstractTestModule.extend({
   },
 
   _setupContainer: function(isolated) {
-    var resolver = getResolver();
+    var resolver = this.resolver;
 
     var items = buildRegistry(!isolated ? resolver : Object.create(resolver, {
       resolve: {
@@ -254,7 +255,7 @@ export default AbstractTestModule.extend({
   },
 
   _setupIsolatedContainer: function() {
-    var resolver = getResolver();
+    var resolver = this.resolver;
     this._setupContainer(true);
 
     var thingToRegisterWith = this.registry || this.container;

--- a/tests/test-module-for-integration-test.js
+++ b/tests/test-module-for-integration-test.js
@@ -3,7 +3,7 @@ import hasEmberVersion from 'ember-test-helpers/has-ember-version';
 import { TestModuleForIntegration } from 'ember-test-helpers';
 import test from 'tests/test-support/qunit-test';
 import qunitModuleFor from 'tests/test-support/qunit-module-for';
-import { setResolverRegistry } from 'tests/test-support/resolver';
+import { setResolverRegistry, createCustomResolver } from 'tests/test-support/resolver';
 
 const Service = Ember.Service || Ember.Object;
 
@@ -273,4 +273,20 @@ test('still in DOM in willDestroyElement', function() {
   this.clearRender();
 
   ok(willDestroyCalled, 'can add assertions after willDestroyElement is called');
+});
+
+moduleForIntegration('TestModuleForIntegration | custom resolver', {
+  resolver: createCustomResolver({
+    'component:y-foo': Ember.Component.extend({
+      name: 'Y u no foo?!'
+    }),
+    'template:components/y-foo': Ember.Handlebars.compile(
+      '<span class="name">{{name}}</span>'
+    )
+  })
+});
+
+test('can render with a custom resolver', function() {
+  this.render('{{y-foo}}');
+  equal(this.$('.name').text(), 'Y u no foo?!', 'rendered properly');
 });

--- a/tests/test-module-test.js
+++ b/tests/test-module-test.js
@@ -3,7 +3,7 @@ import { TestModule, getContext } from 'ember-test-helpers';
 import hasEmberVersion from 'ember-test-helpers/has-ember-version';
 import test from 'tests/test-support/qunit-test';
 import qunitModuleFor from 'tests/test-support/qunit-module-for';
-import { setResolverRegistry } from 'tests/test-support/resolver';
+import { setResolverRegistry, createCustomResolver } from 'tests/test-support/resolver';
 
 function moduleFor(fullName, description, callbacks) {
   var module = new TestModule(fullName, description, callbacks);
@@ -334,4 +334,16 @@ QUnit.module('context can be provided to TestModule', {
 
 test('noop', function() {
   contexts.push(this);
+});
+
+moduleFor('component:y-foo', 'Custom resolver', {
+  resolver: createCustomResolver({
+    'component:y-foo': Ember.Component.extend({
+      name: 'Y u no foo?!'
+    })
+  })
+});
+
+test('subject created using custom resolver', function() {
+  equal(this.subject().name, 'Y u no foo?!');
 });

--- a/tests/test-support/resolver.js
+++ b/tests/test-support/resolver.js
@@ -25,3 +25,19 @@ export default {
     return resolver;
   }
 };
+
+export function createCustomResolver(registry) {
+  var Resolver = Ember.DefaultResolver.extend({
+    registry: null,
+
+    resolve(fullName) {
+      return this.registry[fullName];
+    },
+
+    normalize(fullName) {
+      return Ember.String.dasherize(fullName);
+    }
+  });
+
+  return Resolver.create({ registry, namespace: {} });
+}


### PR DESCRIPTION
Addresses #173. After implementing, I realize this could potentially break some one that has already been using the `resolver` property in their passed in environment, but I think that risk is acceptable.